### PR TITLE
Update crypto HMAC APIs and refactor code

### DIFF
--- a/crypto-ballerina/encrypt_decrypt.bal
+++ b/crypto-ballerina/encrypt_decrypt.bal
@@ -63,7 +63,7 @@ public const OAEPwithSHA512andMGF1 = "OAEPwithSHA512andMGF1";
 # + key - Private or public key used for encryption
 # + padding - The padding
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptRsaEcb(byte[] input, PrivateKey|PublicKey key, RsaPadding padding = "PKCS1")
+public isolated function encryptRsaEcb(byte[] input, PrivateKey|PublicKey key, RsaPadding padding = PKCS1)
                                        returns byte[]|Error = @java:Method {
     name: "encryptRsaEcb",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Encrypt"
@@ -89,7 +89,7 @@ public isolated function encryptRsaEcb(byte[] input, PrivateKey|PublicKey key, R
 # + iv - Initialization vector
 # + padding - The padding
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptAesCbc(byte[] input, byte[] key, byte[] iv, AesPadding padding = "PKCS5")
+public isolated function encryptAesCbc(byte[] input, byte[] key, byte[] iv, AesPadding padding = PKCS5)
                                        returns byte[]|Error = @java:Method {
     name: "encryptAesCbc",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Encrypt"
@@ -110,7 +110,7 @@ public isolated function encryptAesCbc(byte[] input, byte[] key, byte[] iv, AesP
 # + key - Encryption key
 # + padding - The padding
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptAesEcb(byte[] input, byte[] key, AesPadding padding = "PKCS5")
+public isolated function encryptAesEcb(byte[] input, byte[] key, AesPadding padding = PKCS5)
                                        returns byte[]|Error = @java:Method {
     name: "encryptAesEcb",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Encrypt"
@@ -137,7 +137,7 @@ public isolated function encryptAesEcb(byte[] input, byte[] key, AesPadding padd
 # + padding - The padding
 # + tagSize - Tag size
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = "PKCS5",
+public isolated function encryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = PKCS5,
                                        int tagSize = 128) returns byte[]|Error = @java:Method {
     name: "encryptAesGcm",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Encrypt"
@@ -161,7 +161,7 @@ public isolated function encryptAesGcm(byte[] input, byte[] key, byte[] iv, AesP
 # + key - Private or public key used for encryption
 # + padding - The padding
 # + return - Decrypted data or else a `crypto:Error` if the key is invalid
-public isolated function decryptRsaEcb(byte[] input, PrivateKey|PublicKey key, RsaPadding padding = "PKCS1")
+public isolated function decryptRsaEcb(byte[] input, PrivateKey|PublicKey key, RsaPadding padding = PKCS1)
                                        returns byte[]|Error = @java:Method {
     name: "decryptRsaEcb",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decrypt"
@@ -188,7 +188,7 @@ public isolated function decryptRsaEcb(byte[] input, PrivateKey|PublicKey key, R
 # + iv - Initialization vector
 # + padding - The padding
 # + return - Decrypted data or else a `crypto:Error` if the key is invalid
-public isolated function decryptAesCbc(byte[] input, byte[] key, byte[] iv, AesPadding padding = "PKCS5")
+public isolated function decryptAesCbc(byte[] input, byte[] key, byte[] iv, AesPadding padding = PKCS5)
                                        returns byte[]|Error = @java:Method {
     name: "decryptAesCbc",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decrypt"
@@ -210,7 +210,7 @@ public isolated function decryptAesCbc(byte[] input, byte[] key, byte[] iv, AesP
 # + key - Encryption key
 # + padding - The padding
 # + return - Decrypted data or else a `crypto:Error` if the key is invalid
-public isolated function decryptAesEcb(byte[] input, byte[] key, AesPadding padding = "PKCS5")
+public isolated function decryptAesEcb(byte[] input, byte[] key, AesPadding padding = PKCS5)
                                        returns byte[]|Error = @java:Method {
     name: "decryptAesEcb",
    'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decrypt"
@@ -238,7 +238,7 @@ public isolated function decryptAesEcb(byte[] input, byte[] key, AesPadding padd
 # + padding - The padding
 # + tagSize - Tag size
 # + return - Decrypted data or else a `crypto:Error` if the key is invalid
-public isolated function decryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = "PKCS5",
+public isolated function decryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = PKCS5,
                                        int tagSize = 128) returns byte[]|Error = @java:Method {
     name: "decryptAesGcm",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decrypt"

--- a/crypto-ballerina/hmac.bal
+++ b/crypto-ballerina/hmac.bal
@@ -27,8 +27,8 @@ import ballerina/jballerina.java;
 #
 # + input - Value to be hashed
 # + key - Key used for HMAC generation
-# + return - HMAC output
-public isolated function hmacMd5(byte[] input, byte[] key) returns byte[] = @java:Method {
+# + return - HMAC output or `crypto:Error`
+public isolated function hmacMd5(byte[] input, byte[] key) returns byte[]|Error = @java:Method {
     name: "hmacMd5",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Hmac"
 } external;
@@ -44,8 +44,8 @@ public isolated function hmacMd5(byte[] input, byte[] key) returns byte[] = @jav
 #
 # + input - Value to be hashed
 # + key - Key used for HMAC generation
-# + return - HMAC output
-public isolated function hmacSha1(byte[] input, byte[] key) returns byte[] = @java:Method {
+# + return - HMAC output or `crypto:Error`
+public isolated function hmacSha1(byte[] input, byte[] key) returns byte[]|Error = @java:Method {
     name: "hmacSha1",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Hmac"
 } external;
@@ -61,8 +61,8 @@ public isolated function hmacSha1(byte[] input, byte[] key) returns byte[] = @ja
 #
 # + input - Value to be hashed
 # + key - Key used for HMAC generation
-# + return - HMAC output
-public isolated function hmacSha256(byte[] input, byte[] key) returns byte[] = @java:Method {
+# + return - HMAC output or `crypto:Error`
+public isolated function hmacSha256(byte[] input, byte[] key) returns byte[]|Error = @java:Method {
     name: "hmacSha256",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Hmac"
 } external;
@@ -78,8 +78,8 @@ public isolated function hmacSha256(byte[] input, byte[] key) returns byte[] = @
 #
 # + input - Value to be hashed
 # + key - Key used for HMAC generation
-# + return - HMAC output
-public isolated function hmacSha384(byte[] input, byte[] key) returns byte[] = @java:Method {
+# + return - HMAC output or `crypto:Error`
+public isolated function hmacSha384(byte[] input, byte[] key) returns byte[]|Error = @java:Method {
     name: "hmacSha384",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Hmac"
 } external;
@@ -95,8 +95,8 @@ public isolated function hmacSha384(byte[] input, byte[] key) returns byte[] = @
 #
 # + input - Value to be hashed
 # + key - Key used for HMAC generation
-# + return - HMAC output
-public isolated function hmacSha512(byte[] input, byte[] key) returns byte[] = @java:Method {
+# + return - HMAC output or `crypto:Error`
+public isolated function hmacSha512(byte[] input, byte[] key) returns byte[]|Error = @java:Method {
     name: "hmacSha512",
     'class: "org.ballerinalang.stdlib.crypto.nativeimpl.Hmac"
 } external;

--- a/crypto-ballerina/tests/encrypt_decrypt_aes_cbc_test.bal
+++ b/crypto-ballerina/tests/encrypt_decrypt_aes_cbc_test.bal
@@ -53,7 +53,7 @@ isolated function testEncryptAndDecryptWithAesCbcNoPaddingUsingInvalidKeySize() 
     }
     byte[]|Error result = encryptAesCbc(message, invalidKey, iv, NONE);
     if (result is Error) {
-        test:assertEquals(result.message(), "Invalid key size. valid key sizes in bytes: [16, 24, 32]",
+        test:assertEquals(result.message(), "Invalid key size. Valid key sizes in bytes: [16, 24, 32]",
             msg = "Incorrect error for invalid key while No Padding Encryption with AES CBC.");
     } else {
         test:assertFail(msg = "No error for invalid key while No Padding Encryption with AES CBC.");

--- a/crypto-ballerina/tests/encrypt_decrypt_aes_ecb_test.bal
+++ b/crypto-ballerina/tests/encrypt_decrypt_aes_ecb_test.bal
@@ -41,7 +41,7 @@ isolated function testEncryptAndDecryptWithAesEcbNoPaddingUsingInvalidKeySize() 
     }
     byte[]|Error result = encryptAesEcb(message, invalidKey, NONE);
     if (result is Error) {
-        test:assertEquals(result.message(), "Invalid key size. valid key sizes in bytes: [16, 24, 32]",
+        test:assertEquals(result.message(), "Invalid key size. Valid key sizes in bytes: [16, 24, 32]",
             msg = "Incorrect error for invalid key while No Padding Encryption with AES ECB.");
     } else {
         test:assertFail(msg = "No error for invalid key while No Padding Encryption with AES ECB.");

--- a/crypto-ballerina/tests/encrypt_decrypt_aes_gcm_test.bal
+++ b/crypto-ballerina/tests/encrypt_decrypt_aes_gcm_test.bal
@@ -55,7 +55,7 @@ isolated function testEncryptWithAesGcmNoPaddingUsingInvalidInputLength() {
     }
     byte[]|Error result = encryptAesGcm(invalidMessage, key, iv, NONE);
     if (result is Error) {
-        test:assertEquals(result.message(), "Invalid key size. valid key sizes in bytes: [16, 24, 32]",
+        test:assertEquals(result.message(), "Invalid key size. Valid key sizes in bytes: [16, 24, 32]",
             msg = "Incorrect error for invalid key while No Padding Encryption with AES GCM.");
     } else {
         test:assertFail(msg = "No error for invalid input length while No Padding Encryption with AES GCM.");
@@ -79,7 +79,7 @@ isolated function testEncryptAndDecryptWithAesGcmNoPaddingUsingInvalidKeySize() 
     }
     byte[]|Error result = encryptAesGcm(message, invalidKey, iv, NONE, 128);
     if (result is Error) {
-        test:assertEquals(result.message(), "Invalid key size. valid key sizes in bytes: [16, 24, 32]",
+        test:assertEquals(result.message(), "Invalid key size. Valid key sizes in bytes: [16, 24, 32]",
             msg = "Incorrect error for invalid key while No Padding Encryption with AES GCM.");
     } else {
         test:assertFail(msg = "No error for invalid key while No Padding Encryption with AES GCM.");
@@ -124,7 +124,7 @@ isolated function testEncryptAndDecryptWithAesGcmPkcs5WithInvalidTagValue() {
     }
     byte[]|Error result = encryptAesGcm(message, key, iv, "PKCS5", 500);
     if (result is Error) {
-        test:assertTrue(result.message().includes("Invalid tag size. valid tag sizes in bytes:"),
+        test:assertTrue(result.message().includes("Invalid tag size. Valid tag sizes in bytes:"),
             msg = "Incorrect error for invalid key while Encryption with AES GCM PKCS5.");
     } else {
         test:assertFail(msg = "No error for invalid tag size while Encryption with AES GCM PKCS5.");

--- a/crypto-ballerina/tests/hmac_test.bal
+++ b/crypto-ballerina/tests/hmac_test.bal
@@ -21,7 +21,9 @@ isolated function testHmacMd5() {
     byte[] message = "Ballerina HMAC test".toBytes();
     byte[] key = "abcdefghijk".toBytes();
     string expectedMd5Hash = "3D5AC29160F2905A5C8153597798A4C1".toLowerAscii();
-    test:assertEquals(hmacMd5(message, key).toBase16(), expectedMd5Hash, msg = "Error while HMAC with MD5.");
+    byte[]|Error hmac = hmacMd5(message, key);
+    test:assertTrue(hmac is byte[]);
+    test:assertEquals((checkpanic hmac).toBase16(), expectedMd5Hash, msg = "Error while HMAC with MD5.");
 }
 
 @test:Config {}
@@ -29,16 +31,19 @@ isolated function testHmacSha1() {
     byte[] message = "Ballerina HMAC test".toBytes();
     byte[] key = "abcdefghijk".toBytes();
     string expectedSha1Hash = "13DD8D54D0EB702EDC6E8EDCAF616837D3A51499".toLowerAscii();
-    test:assertEquals(hmacSha1(message, key).toBase16(), expectedSha1Hash, msg = "Error while HMAC with SHA1.");
+    byte[]|Error hmac = hmacSha1(message, key);
+    test:assertTrue(hmac is byte[]);
+    test:assertEquals((checkpanic hmac).toBase16(), expectedSha1Hash, msg = "Error while HMAC with SHA1.");
 }
 
 @test:Config {}
 isolated function testHmacSha256() {
     byte[] message = "Ballerina HMAC test".toBytes();
     byte[] key = "abcdefghijk".toBytes();
-    string expectedSha256Hash =
-        "2651203E18BF0088D3EF1215022D147E2534FD4BAD5689C9E5F12436E9758B15".toLowerAscii();
-    test:assertEquals(hmacSha256(message, key).toBase16(), expectedSha256Hash, msg = "Error while HMAC with SHA256.");
+    string expectedSha256Hash = "2651203E18BF0088D3EF1215022D147E2534FD4BAD5689C9E5F12436E9758B15".toLowerAscii();
+    byte[]|Error hmac = hmacSha256(message, key);
+    test:assertTrue(hmac is byte[]);
+    test:assertEquals((checkpanic hmac).toBase16(), expectedSha256Hash, msg = "Error while HMAC with SHA256.");
 }
 
 @test:Config {}
@@ -47,7 +52,9 @@ isolated function testHmacSha384() {
     byte[] key = "abcdefghijk".toBytes();
     string expectedSha384Hash = ("c27a281dffed3d4d176646d7261e9f6268a3d40a237cd274fc2f5970f637f1c" +
         "bc20a3835d7b7aa7401308737f23a9bf7").toLowerAscii();
-    test:assertEquals(hmacSha384(message, key).toBase16(), expectedSha384Hash, msg = "Error while HMAC with SHA384.");
+    byte[]|Error hmac = hmacSha384(message, key);
+    test:assertTrue(hmac is byte[]);
+    test:assertEquals((checkpanic hmac).toBase16(), expectedSha384Hash, msg = "Error while HMAC with SHA384.");
 }
 
 @test:Config {}
@@ -56,35 +63,47 @@ isolated function testHmacSha512() {
     byte[] key = "abcdefghijk".toBytes();
     string expectedSha512Hash = ("78d99bf3e5277fc893af6cd6b0487c33ed3abc4f956fdd1fada302f135b012a" +
         "3c71cadaaeb462e51ff281202bdfa8807719b91f69742c3f71f036c469ac5b918").toLowerAscii();
-    test:assertEquals(hmacSha512(message, key).toBase16(), expectedSha512Hash, msg = "Error while HMAC with SHA512.");
+    byte[]|Error hmac = hmacSha512(message, key);
+    test:assertTrue(hmac is byte[]);
+    test:assertEquals((checkpanic hmac).toBase16(), expectedSha512Hash, msg = "Error while HMAC with SHA512.");
 }
 
 @test:Config {}
-isolated function testHmacMd5WithInvalidKey() {
+isolated function testHmacMd5WithEmptyKey() {
     byte[] message = "Ballerina HMAC test".toBytes();
-    test:assertTrue((trap hmacMd5(message, [])) is error, msg = "No error for empty key while HMAC with MD5.");
+    byte[]|Error hmac = hmacMd5(message, []);
+    test:assertTrue(hmac is Error);
+    test:assertEquals((<Error>hmac).message(), "Error occurred while calculating HMAC: Empty key");
 }
 
 @test:Config {}
-isolated function testHmacSha1WithInvalidKey() {
+isolated function testHmacSha1WithEmptyKey() {
     byte[] message = "Ballerina HMAC test".toBytes();
-    test:assertTrue((trap hmacSha1(message, [])) is error, msg = "No error for empty key while HMAC with SHA1.");
+    byte[]|Error hmac = hmacSha1(message, []);
+    test:assertTrue(hmac is Error);
+    test:assertEquals((<Error>hmac).message(), "Error occurred while calculating HMAC: Empty key");
 }
 
 @test:Config {}
-isolated function testHmacSha256WithInvalidKey() {
+isolated function testHmacSha256WithEmptyKey() {
     byte[] message = "Ballerina HMAC test".toBytes();
-    test:assertTrue((trap hmacSha256(message, [])) is error, msg = "No error for empty key while HMAC with SHA256.");
+    byte[]|Error hmac = hmacSha256(message, []);
+    test:assertTrue(hmac is Error);
+    test:assertEquals((<Error>hmac).message(), "Error occurred while calculating HMAC: Empty key");
 }
 
 @test:Config {}
-isolated function testHmacSha384WithInvalidKey() {
+isolated function testHmacSha384WithEmptyKey() {
     byte[] message = "Ballerina HMAC test".toBytes();
-    test:assertTrue((trap hmacSha384(message, [])) is error, msg = "No error for empty key while HMAC with SHA384.");
+    byte[]|Error hmac = hmacSha384(message, []);
+    test:assertTrue(hmac is Error);
+    test:assertEquals((<Error>hmac).message(), "Error occurred while calculating HMAC: Empty key");
 }
 
 @test:Config {}
-isolated function testHmacSha512WithInvalidKey() {
+isolated function testHmacSha512WithEmptyKey() {
     byte[] message = "Ballerina HMAC test".toBytes();
-    test:assertTrue((trap hmacSha512(message, [])) is error, msg = "No error for empty key while HMAC with SHA512.");
+    byte[]|Error hmac = hmacSha512(message, []);
+    test:assertTrue(hmac is Error);
+    test:assertEquals((<Error>hmac).message(), "Error occurred while calculating HMAC: Empty key");
 }

--- a/crypto-native/src/main/java/org/ballerinalang/stdlib/crypto/CryptoUtils.java
+++ b/crypto-native/src/main/java/org/ballerinalang/stdlib/crypto/CryptoUtils.java
@@ -66,12 +66,12 @@ public class CryptoUtils {
     /**
      * Valid tag sizes usable with GCM mode encryption.
      */
-    private static final int[] VALID_GCM_TAG_SIZES = new int[] { 32, 63, 96, 104, 112, 120, 128 };
+    private static final int[] VALID_GCM_TAG_SIZES = new int[]{32, 63, 96, 104, 112, 120, 128};
 
     /**
      * Valid AES key sizes.
      */
-    private static final int[] VALID_AES_KEY_SIZES = new int[] { 16, 24, 32 };
+    private static final int[] VALID_AES_KEY_SIZES = new int[]{16, 24, 32};
 
     private CryptoUtils() {
 
@@ -83,15 +83,17 @@ public class CryptoUtils {
      * @param algorithm algorithm used during HMAC generation
      * @param key       key used during HMAC generation
      * @param input     input byte array for HMAC generation
-     * @return calculated HMAC value
+     * @return calculated HMAC value or error if key is invalid
      */
-    public static byte[] hmac(String algorithm, byte[] key, byte[] input) {
+    public static Object hmac(String algorithm, byte[] key, byte[] input) {
         try {
             SecretKey secretKey = new SecretKeySpec(key, algorithm);
             Mac mac = Mac.getInstance(algorithm);
             mac.init(secretKey);
-            return mac.doFinal(input);
-        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            return ValueCreator.createArrayValue(mac.doFinal(input));
+        } catch (InvalidKeyException | IllegalArgumentException e) {
+            return CryptoUtils.createError("Error occurred while calculating HMAC: " + e.getMessage());
+        } catch (NoSuchAlgorithmException e) {
             throw CryptoUtils.createError("Error occurred while calculating HMAC: " + e.getMessage());
         }
     }
@@ -105,8 +107,7 @@ public class CryptoUtils {
      */
     public static byte[] hash(String algorithm, byte[] input) {
         try {
-            MessageDigest messageDigest;
-            messageDigest = MessageDigest.getInstance(algorithm);
+            MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
             messageDigest.update(input);
             return messageDigest.digest();
         } catch (NoSuchAlgorithmException e) {
@@ -189,15 +190,15 @@ public class CryptoUtils {
             }
             AlgorithmParameterSpec paramSpec = buildParameterSpec(transformedAlgorithmMode, iv, (int) tagSize);
             Cipher cipher = Cipher.getInstance(Constants.RSA + "/" + transformedAlgorithmMode + "/"
-                    + transformedAlgorithmPadding);
+                                                       + transformedAlgorithmPadding);
             initCipher(cipher, cipherMode, key, paramSpec);
             return ValueCreator.createArrayValue(cipher.doFinal(input));
         } catch (NoSuchAlgorithmException e) {
             return CryptoUtils.createError("Unsupported algorithm: RSA " + algorithmMode + " " + algorithmPadding +
-                    ": " + e.getMessage());
+                                                   ": " + e.getMessage());
         } catch (NoSuchPaddingException e) {
             return CryptoUtils.createError("Unsupported padding scheme defined in the algorithm: RSA "
-                    + algorithmMode + " " + algorithmPadding + ": " + e.getMessage());
+                                                   + algorithmMode + " " + algorithmPadding + ": " + e.getMessage());
         } catch (InvalidKeyException | InvalidAlgorithmParameterException | BadPaddingException |
                 IllegalBlockSizeException | BError e) {
             return CryptoUtils.createError("Error occurred while RSA encrypt/decrypt: " + e.getMessage());
@@ -220,15 +221,15 @@ public class CryptoUtils {
                                            String algorithmPadding, byte[] key, byte[] input, byte[] iv, long tagSize) {
         try {
             if (Arrays.stream(VALID_AES_KEY_SIZES).noneMatch(validSize -> validSize == key.length)) {
-                return CryptoUtils.createError("Invalid key size. valid key sizes in bytes: " +
-                        Arrays.toString(VALID_AES_KEY_SIZES));
+                return CryptoUtils.createError("Invalid key size. Valid key sizes in bytes: " +
+                                                       Arrays.toString(VALID_AES_KEY_SIZES));
             }
             String transformedAlgorithmMode = transformAlgorithmMode(algorithmMode);
             String transformedAlgorithmPadding = transformAlgorithmPadding(algorithmPadding);
             SecretKeySpec keySpec = new SecretKeySpec(key, Constants.AES);
             if (tagSize != -1 && Arrays.stream(VALID_GCM_TAG_SIZES).noneMatch(validSize -> validSize == tagSize)) {
-                return CryptoUtils.createError("Invalid tag size. valid tag sizes in bytes: " +
-                        Arrays.toString(VALID_GCM_TAG_SIZES));
+                return CryptoUtils.createError("Invalid tag size. Valid tag sizes in bytes: " +
+                                                       Arrays.toString(VALID_GCM_TAG_SIZES));
             }
             AlgorithmParameterSpec paramSpec = buildParameterSpec(transformedAlgorithmMode, iv, (int) tagSize);
             Cipher cipher = Cipher.getInstance("AES/" + transformedAlgorithmMode + "/" + transformedAlgorithmPadding);
@@ -236,10 +237,10 @@ public class CryptoUtils {
             return ValueCreator.createArrayValue(cipher.doFinal(input));
         } catch (NoSuchAlgorithmException e) {
             return CryptoUtils.createError("Unsupported algorithm: AES " + algorithmMode + " " + algorithmPadding +
-                    ": " + e.getMessage());
+                                                   ": " + e.getMessage());
         } catch (NoSuchPaddingException e) {
             return CryptoUtils.createError("Unsupported padding scheme defined in  the algorithm: AES " +
-                    algorithmMode + " " + algorithmPadding + ": " + e.getMessage());
+                                                   algorithmMode + " " + algorithmPadding + ": " + e.getMessage());
         } catch (BadPaddingException | IllegalBlockSizeException | InvalidAlgorithmParameterException |
                 InvalidKeyException | BError e) {
             return CryptoUtils.createError("Error occurred while AES encrypt/decrypt: " + e.getMessage());
@@ -362,12 +363,12 @@ public class CryptoUtils {
     }
 
     /**
-     * Replace system property holders in the property values.
-     * e.g. Replace ${ballerina.home} with value of the ballerina.home system property.
+     * Replace system property holders in the property values. e.g. Replace ${ballerina.home} with value of the
+     * ballerina.home system property.
      * <p>
-     * This logic is originally from http-transport-utils. Since, HTTP stdlib depends on http-transport,
-     * HTTP stdlib directly uses this method form the original utility. This is added here, not to make Auth stdlib
-     * depend on http-transport.
+     * This logic is originally from http-transport-utils. Since, HTTP stdlib depends on http-transport, HTTP stdlib
+     * directly uses this method form the original utility. This is added here, not to make Auth stdlib depend on
+     * http-transport.
      *
      * @param value string value to substitute
      * @return String substituted string
@@ -389,7 +390,8 @@ public class CryptoUtils {
 
                 sysPropValue = sysPropValue.replace("\\", "\\\\");
                 matcher.appendReplacement(sb, sysPropValue);
-            } while (matcher.find());
+            }
+            while (matcher.find());
 
             matcher.appendTail(sb);
             return sb.toString();

--- a/crypto-native/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Hmac.java
+++ b/crypto-native/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Hmac.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.stdlib.crypto.nativeimpl;
 
-import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BArray;
 import org.ballerinalang.stdlib.crypto.CryptoUtils;
 
@@ -29,26 +28,23 @@ import org.ballerinalang.stdlib.crypto.CryptoUtils;
  */
 public class Hmac {
 
-    public static BArray hmacMd5(BArray inputValue, BArray keyValue) {
-        return ValueCreator.createArrayValue(CryptoUtils.hmac("HmacMD5", keyValue.getBytes(), inputValue.getBytes()));
+    public static Object hmacMd5(BArray inputValue, BArray keyValue) {
+        return CryptoUtils.hmac("HmacMD5", keyValue.getBytes(), inputValue.getBytes());
     }
 
-    public static BArray hmacSha1(BArray inputValue, BArray keyValue) {
-        return ValueCreator.createArrayValue(CryptoUtils.hmac("HmacSHA1", keyValue.getBytes(), inputValue.getBytes()));
+    public static Object hmacSha1(BArray inputValue, BArray keyValue) {
+        return CryptoUtils.hmac("HmacSHA1", keyValue.getBytes(), inputValue.getBytes());
     }
 
-    public static BArray hmacSha256(BArray inputValue, BArray keyValue) {
-        return ValueCreator
-                .createArrayValue(CryptoUtils.hmac("HmacSHA256", keyValue.getBytes(), inputValue.getBytes()));
+    public static Object hmacSha256(BArray inputValue, BArray keyValue) {
+        return CryptoUtils.hmac("HmacSHA256", keyValue.getBytes(), inputValue.getBytes());
     }
 
-    public static BArray hmacSha384(BArray inputValue, BArray keyValue) {
-        return ValueCreator
-                .createArrayValue(CryptoUtils.hmac("HmacSHA384", keyValue.getBytes(), inputValue.getBytes()));
+    public static Object hmacSha384(BArray inputValue, BArray keyValue) {
+        return CryptoUtils.hmac("HmacSHA384", keyValue.getBytes(), inputValue.getBytes());
     }
 
-    public static BArray hmacSha512(BArray inputValue, BArray keyValue) {
-        return ValueCreator
-                .createArrayValue(CryptoUtils.hmac("HmacSHA512", keyValue.getBytes(), inputValue.getBytes()));
+    public static Object hmacSha512(BArray inputValue, BArray keyValue) {
+        return CryptoUtils.hmac("HmacSHA512", keyValue.getBytes(), inputValue.getBytes());
     }
 }


### PR DESCRIPTION
## Purpose
This PR updates the `ballerina/crypto` module API for `HMAC` operations with the return of `crypto:Error`.

Old APIs:
```ballerina
public isolated function hmacMd5(byte[] input, byte[] key) returns byte[];
public isolated function hmacSha1(byte[] input, byte[] key) returns byte[];
public isolated function hmacSha256(byte[] input, byte[] key) returns byte[];
public isolated function hmacSha384(byte[] input, byte[] key) returns byte[];
public isolated function hmacSha512(byte[] input, byte[] key) returns byte[];
```

Updated APIs:
```ballerina
public isolated function hmacMd5(byte[] input, byte[] key) returns byte[]|Error;
public isolated function hmacSha1(byte[] input, byte[] key) returns byte[]|Error;
public isolated function hmacSha256(byte[] input, byte[] key) returns byte[]|Error;
public isolated function hmacSha384(byte[] input, byte[] key) returns byte[]|Error;
public isolated function hmacSha512(byte[] input, byte[] key) returns byte[]|Error;
```

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/908
Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584