### PR TITLE
Return nil explicitly from functions

### DIFF
--- a/ballerina/tests/encrypt_decrypt_aes_cbc_test.bal
+++ b/ballerina/tests/encrypt_decrypt_aes_cbc_test.bal
@@ -34,6 +34,7 @@ isolated function testEncryptAndDecryptWithAesCbcNoPadding() returns Error? {
     byte[] cipherText = check encryptAesCbc(message, key, iv, NONE);
     byte[] plainText = check decryptAesCbc(cipherText, key, iv, NONE);
     test:assertEquals(plainText.toBase16(), message.toBase16(), msg = "Error while Encrypt/Decrypt with AES CBC.");
+    return;
 }
 
 @test:Config {}
@@ -108,6 +109,7 @@ isolated function testEncryptAndDecryptWithAesCbcNoPaddingUsingInvalidInputLengt
     } else {
         test:assertFail(msg = "No error for invalid input length while No Padding Encryption with AES CBC.");
     }
+    return;
 }
 
 @test:Config {}
@@ -129,4 +131,5 @@ isolated function testEncryptAndDecryptWithAesCbcPkcs5() returns Error? {
     byte[] plainText = check decryptAesCbc(cipherText, key, iv, "PKCS5");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with AES CBC PKCS5.");
+    return;
 }

--- a/ballerina/tests/encrypt_decrypt_aes_ecb_test.bal
+++ b/ballerina/tests/encrypt_decrypt_aes_ecb_test.bal
@@ -28,6 +28,7 @@ isolated function testEncryptAndDecryptWithAesEcbNoPadding() returns Error? {
     byte[] cipherText = check encryptAesEcb(message, key, NONE);
     byte[] plainText = check decryptAesEcb(cipherText, key, NONE);
     test:assertEquals(plainText.toBase16(), message.toBase16(), msg = "Error while Encrypt/Decrypt with AES ECB.");
+    return;
 }
 
 @test:Config {}
@@ -79,4 +80,5 @@ isolated function testEncryptAndDecryptWithAesEcbPkcs5() returns Error? {
     byte[] cipherText = check encryptAesEcb(message, key, "PKCS5");
     byte[] plainText = check decryptAesEcb(cipherText, key, "PKCS5");
     test:assertEquals(plainText.toBase16(), message.toBase16(), msg = "Error while Encrypt/Decrypt with AES ECB PKCS5.");
+    return;
 }

--- a/ballerina/tests/encrypt_decrypt_aes_gcm_test.bal
+++ b/ballerina/tests/encrypt_decrypt_aes_gcm_test.bal
@@ -34,6 +34,7 @@ isolated function testEncryptAndDecryptWithAesGcmNoPadding() returns Error? {
     byte[] cipherText = check encryptAesGcm(message, key, iv, NONE, 128);
     byte[] plainText = check decryptAesGcm(cipherText, key, iv, NONE, 128);
     test:assertEquals(plainText.toBase16(), message.toBase16(), msg = "Error while Encrypt/Decrypt with AES GCM.");
+    return;
 }
 
 @test:Config {
@@ -105,6 +106,7 @@ isolated function testEncryptAndDecryptWithAesGcmPkcs5() returns Error? {
     byte[] plainText = check decryptAesGcm(cipherText, key, iv, "PKCS5");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with AES GCM PKCS5.");
+    return;
 }
 
 @test:Config {}

--- a/ballerina/tests/encrypt_decrypt_rsa_ecb_test.bal
+++ b/ballerina/tests/encrypt_decrypt_rsa_ecb_test.bal
@@ -29,6 +29,7 @@ isolated function testEncryptAndDecryptWithRsaEcbPkcs1() returns Error? {
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "PKCS1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB PKCS1.");
+    return;
 }
 
 @test:Config {}
@@ -44,6 +45,7 @@ isolated function testEncryptAndDecryptWithRsaEcbOAEPwithMd5andMgf1() returns Er
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "OAEPwithMD5andMGF1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB OAEPwithMD5andMGF1.");
+    return;
 }
 
 @test:Config {}
@@ -59,6 +61,7 @@ isolated function testEncryptAndDecryptWithRsaEcbOaepWithSha1AndMgf1() returns E
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "OAEPWithSHA1AndMGF1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB OAEPWithSHA1AndMGF1.");
+    return;
 }
 
 @test:Config {}
@@ -74,6 +77,7 @@ isolated function testEncryptAndDecryptWithRsaEcbOaepWithSha256AndMgf1() returns
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "OAEPWithSHA256AndMGF1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB OAEPWithSHA256AndMGF1.");
+    return;
 }
 
 @test:Config {}
@@ -89,6 +93,7 @@ isolated function testEncryptAndDecryptWithRsaEcbOaepWithSha384andMgf1() returns
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "OAEPwithSHA384andMGF1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB OAEPwithSHA384andMGF1.");
+    return;
 }
 
 @test:Config {}
@@ -104,6 +109,7 @@ isolated function testEncryptAndDecryptWithRsaEcbOaepWithSha512andMgf1() returns
     byte[] plainText = check decryptRsaEcb(cipherText, privateKey, "OAEPwithSHA512andMGF1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB OAEPwithSHA512andMGF1.");
+    return;
 }
 
 @test:Config {}
@@ -119,6 +125,7 @@ isolated function testEncryptWithPrivateKeyAndDecryptWithPublicKeyUsingRsaEcbPkc
     byte[] plainText = check decryptRsaEcb(cipherText, publicKey, "PKCS1");
     test:assertEquals(plainText.toBase16(), message.toBase16(),
         msg = "Error while Encrypt/Decrypt with RSA ECB PKCS1.");
+    return;
 }
 
 @test:Config {}

--- a/ballerina/tests/hmac_test.bal
+++ b/ballerina/tests/hmac_test.bal
@@ -24,6 +24,7 @@ isolated function testHmacMd5() returns Error? {
     byte[]|Error hmac = hmacMd5(message, key);
     test:assertTrue(hmac is byte[]);
     test:assertEquals((check hmac).toBase16(), expectedMd5Hash, msg = "Error while HMAC with MD5.");
+    return;
 }
 
 @test:Config {}
@@ -34,6 +35,7 @@ isolated function testHmacSha1() returns Error? {
     byte[]|Error hmac = hmacSha1(message, key);
     test:assertTrue(hmac is byte[]);
     test:assertEquals((check hmac).toBase16(), expectedSha1Hash, msg = "Error while HMAC with SHA1.");
+    return;
 }
 
 @test:Config {}
@@ -44,6 +46,7 @@ isolated function testHmacSha256() returns Error? {
     byte[]|Error hmac = hmacSha256(message, key);
     test:assertTrue(hmac is byte[]);
     test:assertEquals((check hmac).toBase16(), expectedSha256Hash, msg = "Error while HMAC with SHA256.");
+    return;
 }
 
 @test:Config {}
@@ -55,6 +58,7 @@ isolated function testHmacSha384() returns Error? {
     byte[]|Error hmac = hmacSha384(message, key);
     test:assertTrue(hmac is byte[]);
     test:assertEquals((check hmac).toBase16(), expectedSha384Hash, msg = "Error while HMAC with SHA384.");
+    return;
 }
 
 @test:Config {}
@@ -66,6 +70,7 @@ isolated function testHmacSha512() returns Error? {
     byte[]|Error hmac = hmacSha512(message, key);
     test:assertTrue(hmac is byte[]);
     test:assertEquals((check hmac).toBase16(), expectedSha512Hash, msg = "Error while HMAC with SHA512.");
+    return;
 }
 
 @test:Config {}

--- a/ballerina/tests/private_public_key_test.bal
+++ b/ballerina/tests/private_public_key_test.bal
@@ -204,6 +204,7 @@ isolated function testParsePublicKeyFromP12() returns Error? {
         msg = "Error while checking subject from encrypted public-key from a p12 file.");
     test:assertEquals(signingAlgorithm, "SHA256withRSA",
         msg = "Error while checking signingAlgorithm from encrypted public-key from a p12 file.");
+    return;
 }
 
 @test:Config {}
@@ -270,6 +271,7 @@ isolated function testParsePublicKeyFromX509CertFile() returns Error? {
         msg = "Error while checking subject from public-key from a cert file.");
     test:assertEquals(signingAlgorithm, "SHA256withRSA",
         msg = "Error while checking signingAlgorithm from public-key from a cert file.");
+    return;
 }
 
 @test:Config {}
@@ -303,6 +305,7 @@ isolated function testBuildPublicKeyFromJwk() returns Error? {
     string exponent = "AQAB";
     PublicKey publicKey = check buildRsaPublicKey(modulus, exponent);
     test:assertEquals(publicKey["algorithm"], "RSA", msg = "Error while building public key from JWK.");
+    return;
 }
 
 @test:Config {}

--- a/ballerina/tests/sign_verify_test.bal
+++ b/ballerina/tests/sign_verify_test.bal
@@ -32,6 +32,7 @@ isolated function testSignRsaMd5() returns Error? {
         "67145ec0e6e8abfc3f7f10122cc278b5469eb970034483839f290eec";
     byte[] md5Signature = check signRsaMd5(payload, privateKey);
     test:assertEquals(md5Signature.toBase16(), expectedMd5Signature, msg = "Error while RSA sign with MD5.");
+    return;
 }
 
 @test:Config {}
@@ -50,6 +51,7 @@ isolated function testSignRsaSha1() returns Error? {
         "02f7840f8991b8c335b0332b3b4bd658030ec3007f6f36c190b8663d3b746";
     byte[] sha1Signature = check signRsaSha1(payload, privateKey);
     test:assertEquals(sha1Signature.toBase16(), expectedSha1Signature, msg = "Error while RSA sign with SHA1.");
+    return;
 }
 
 @test:Config {}
@@ -68,6 +70,7 @@ isolated function testSignRsaSha256() returns Error? {
         "0c11ef2a0d32088d4683d915005c9dcc8137611e5bff9dc4a5db6f87";
     byte[] sha256Signature = check signRsaSha256(payload, privateKey);
     test:assertEquals(sha256Signature.toBase16(), expectedSha256Signature, msg = "Error while RSA sign with SHA256.");
+    return;
 }
 
 @test:Config {}
@@ -86,6 +89,7 @@ isolated function testSignRsaSha384() returns Error? {
         "EF7D8F8BF0659E1D6B77916B4AEEC79989AFDAA2F5B8983DE476C1A0FFBB2B647DE449E").toLowerAscii();
     byte[] sha384Signature = check signRsaSha384(payload, privateKey);
     test:assertEquals(sha384Signature.toBase16(), expectedSha384Signature, msg = "Error while RSA sign with SHA384.");
+    return;
 }
 
 @test:Config {}
@@ -104,6 +108,7 @@ isolated function testSignRsaSha512() returns Error? {
         "9cb2e6e669ec3352073a8933a2a0cac6056b4997b3628132f7a7e553";
     byte[] sha512Signature = check signRsaSha512(payload, privateKey);
     test:assertEquals(sha512Signature.toBase16(), expectedSha512Signature, msg = "Error while RSA sign with SHA512.");
+    return;
 }
 
 @test:Config {}
@@ -193,6 +198,7 @@ isolated function testVerifyRsaMd5() returns Error? {
         "67145ec0e6e8abfc3f7f10122cc278b5469eb970034483839f290eec";
     byte[] md5Signature = check signRsaMd5(payload, privateKey);
     test:assertTrue(check verifyRsaMd5Signature(payload, md5Signature, publicKey));
+    return;
 }
 
 @test:Config {}
@@ -212,6 +218,7 @@ isolated function testVerifyRsaSha1() returns Error? {
         "02f7840f8991b8c335b0332b3b4bd658030ec3007f6f36c190b8663d3b746";
     byte[] sha1Signature = check signRsaSha1(payload, privateKey);
     test:assertTrue(check verifyRsaSha1Signature(payload, sha1Signature, publicKey));
+    return;
 }
 
 @test:Config {}
@@ -231,6 +238,7 @@ isolated function testVerifyRsaSha256() returns Error? {
         "0c11ef2a0d32088d4683d915005c9dcc8137611e5bff9dc4a5db6f87";
     byte[] sha256Signature = check signRsaSha256(payload, privateKey);
     test:assertTrue(check verifyRsaSha256Signature(payload, sha256Signature, publicKey));
+    return;
 }
 
 @test:Config {}
@@ -250,6 +258,7 @@ isolated function testVerifyRsaSha384() returns Error? {
         "EF7D8F8BF0659E1D6B77916B4AEEC79989AFDAA2F5B8983DE476C1A0FFBB2B647DE449E").toLowerAscii();
     byte[] sha384Signature = check signRsaSha384(payload, privateKey);
     test:assertTrue(check verifyRsaSha384Signature(payload, sha384Signature, publicKey));
+    return;
 }
 
 @test:Config {}
@@ -269,4 +278,5 @@ isolated function testVerifyRsaSha512() returns Error? {
         "9cb2e6e669ec3352073a8933a2a0cac6056b4997b3628132f7a7e553";
     byte[] sha512Signature = check signRsaSha512(payload, privateKey);
     test:assertTrue(check verifyRsaSha512Signature(payload, sha512Signature, publicKey));
+    return;
 }


### PR DESCRIPTION
## Purpose
$subject to remove the warning `this function should explicitly return a value`.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
