### PR TITLE
Return error for signature exceptions

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/crypto/CryptoUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/crypto/CryptoUtils.java
@@ -129,7 +129,9 @@ public class CryptoUtils {
             return ValueCreator.createArrayValue(sig.sign());
         } catch (InvalidKeyException e) {
             return CryptoUtils.createError("Uninitialized private key: " + e.getMessage());
-        } catch (NoSuchAlgorithmException | SignatureException e) {
+        } catch (SignatureException e) {
+            return CryptoUtils.createError("Error occurred while calculating signature: " + e.getMessage());
+        } catch (NoSuchAlgorithmException e) {
             throw CryptoUtils.createError("Error occurred while calculating signature: " + e.getMessage());
         }
     }
@@ -151,7 +153,9 @@ public class CryptoUtils {
             return sig.verify(signature);
         } catch (InvalidKeyException e) {
             return CryptoUtils.createError("Uninitialized public key: " + e.getMessage());
-        } catch (NoSuchAlgorithmException | SignatureException e) {
+        } catch (SignatureException e) {
+            return CryptoUtils.createError("Error occurred while calculating signature: " + e.getMessage());
+        } catch (NoSuchAlgorithmException e) {
             throw CryptoUtils.createError("Error occurred while calculating signature: " + e.getMessage());
         }
     }


### PR DESCRIPTION
## Purpose
This PR change the behaviour of cryptographically sign and validation by returning the `java.security.SignatureException` instead of throwing.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
