### PR TITLE
Update encryptAesGcm default padding value to NONE

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0-20230726-145300-b2bdf796"
+distribution-version = "2201.8.0-20230830-220400-8a7556d8"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/encrypt_decrypt.bal
+++ b/ballerina/encrypt_decrypt.bal
@@ -137,7 +137,7 @@ public isolated function encryptAesEcb(byte[] input, byte[] key, AesPadding padd
 # + padding - The padding algorithm
 # + tagSize - Tag size
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = PKCS5,
+public isolated function encryptAesGcm(byte[] input, byte[] key, byte[] iv, AesPadding padding = NONE,
                                        int tagSize = 128) returns byte[]|Error = @java:Method {
     name: "encryptAesGcm",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Encrypt"

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- [Remove support for AES/GCM/PKCS5ZPadding algorithm](https://github.com/ballerina-platform/ballerina-standard-library/issues/4775)
+
 ## [2.4.0] - 2023-06-30
 
 - This version maintains the latest dependency versions.


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4775

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
