### PR TITLE
[2201.7.x] Downgrade Bouncy Castle version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -21,11 +21,11 @@ path = "../native/build/libs/crypto-native-2.4.1-SNAPSHOT.jar"
 [[platform.java11.dependency]]
 groupId = "org.bouncycastle"
 artifactId = "bcpkix-jdk18on"
-version = "1.76"
-path = "./lib/bcpkix-jdk18on-1.76.jar"
+version = "1.74"
+path = "./lib/bcpkix-jdk18on-1.74.jar"
 
 [[platform.java11.dependency]]
 groupId = "org.bouncycastle"
 artifactId = "bcprov-jdk18on"
-version = "1.76"
-path = "./lib/bcprov-jdk18on-1.76.jar"
+version = "1.74"
+path = "./lib/bcprov-jdk18on-1.74.jar"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.4.1-SNAPSHOT
 puppycrawlCheckstyleVersion=8.18
-bouncycastleVersion=1.76
+bouncycastleVersion=1.74
 ballerinaGradlePluginVersion=1.1.0
 nativeImageVersion=22.2.0
 


### PR DESCRIPTION
## Purpose
Related to: ballerina-platform/ballerina-standard-library#4776

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
