### PR TITLE
[Update 11] Rename `publicKeyPath` and `privateKeyPath` parameters

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "crypto"
-version = "2.7.2"
+version = "2.7.3"
 authors = ["Ballerina"]
 keywords = ["security", "hash", "hmac", "sign", "encrypt", "decrypt", "private key", "public key"]
 repository = "https://github.com/ballerina-platform/module-ballerina-crypto"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "crypto-native"
-version = "2.7.2"
-path = "../native/build/libs/crypto-native-2.7.2.jar"
+version = "2.7.3"
+path = "../native/build/libs/crypto-native-2.7.3-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.bouncycastle"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.9.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.7.2"
+version = "2.7.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},

--- a/ballerina/encrypt_decrypt.bal
+++ b/ballerina/encrypt_decrypt.bal
@@ -251,10 +251,10 @@ public isolated function decryptAesGcm(byte[] input, byte[] key, byte[] iv, AesP
 # ```
 #
 # + plainText - The content to be encrypted
-# + publicKeyPath - Path to the public key
+# + publicKey - Path to the public key
 # + options - PGP encryption options
 # + return - Encrypted data or else a `crypto:Error` if the key is invalid
-public isolated function encryptPgp(byte[] plainText, string publicKeyPath, *Options options)
+public isolated function encryptPgp(byte[] plainText, string publicKey, *Options options)
                                        returns byte[]|Error = @java:Method {
     name: "encryptPgp",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Encrypt"
@@ -270,10 +270,10 @@ public isolated function encryptPgp(byte[] plainText, string publicKeyPath, *Opt
 # ```
 #
 # + cipherText - The encrypted content to be decrypted
-# + privateKeyPath - Path to the private key
+# + privateKey - Path to the private key
 # + passphrase - passphrase of the private key
 # + return - Decrypted data or else a `crypto:Error` if the key or passphrase is invalid
-public isolated function decryptPgp(byte[] cipherText, string privateKeyPath, byte[] passphrase)
+public isolated function decryptPgp(byte[] cipherText, string privateKey, byte[] passphrase)
                                        returns byte[]|Error = @java:Method {
     name: "decryptPgp",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Decrypt"


### PR DESCRIPTION
## Purpose

Renaming the `publicKeyPath` and the `privateKeyPath` parameters in the PGP APIs, to `publicKey` and `privateKey`

**Note:** This will be a breaking change if the API is used with named arguments

## Examples

N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
