### PR TITLE
Implement static code analysis rule to analyse weak encryption algorithm usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ target
 # Ballerina
 velocity.log*
 *Ballerina.lock
+
+compiler-plugin-tests/**/target

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "crypto-compiler-plugin"
+class = "io.ballerina.stdlib.crypto.compiler.CryptoCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.9.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -114,4 +114,3 @@ dependencies = [
 modules = [
 	{org = "ballerina", packageName = "time", moduleName = "time"}
 ]
-

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -114,3 +114,4 @@ dependencies = [
 modules = [
 	{org = "ballerina", packageName = "time", moduleName = "time"}
 ]
+

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -28,6 +28,8 @@ def packageOrg = "ballerina"
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/Ballerina.toml")
+def compilerPluginTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/CompilerPlugin.toml")
+def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -68,18 +70,20 @@ dependencies {
     }
 }
 
-task updateTomlFiles {
+tasks.register('updateTomlFiles') {
     doLast {
         def stdlibDependentBouncycastleVersion = project.bouncycastleVersion
 
         def newBallerinaToml = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newBallerinaToml = newBallerinaToml.replace("@toml.version@", tomlVersion)
         newBallerinaToml = newBallerinaToml.replace("@bouncycastle.version@", stdlibDependentBouncycastleVersion)
+        def newCompilerPluginToml = compilerPluginTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         ballerinaTomlFile.text = newBallerinaToml
+        compilerPluginTomlFile.text = newCompilerPluginToml
     }
 }
 
-task commitTomlFiles {
+tasks.register('commitTomlFiles') {
     doLast {
         project.exec {
             ignoreExitValue true
@@ -117,6 +121,8 @@ test.dependsOn ":${packageName}-native:build"
 
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
+build.dependsOn ":${packageName}-compiler-plugin:build"
+test.dependsOn ":${packageName}-compiler-plugin:build"
 
 publishToMavenLocal.dependsOn build
 publish.dependsOn build

--- a/build-config/resources/CompilerPlugin.toml
+++ b/build-config/resources/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "crypto-compiler-plugin"
+class = "io.ballerina.stdlib.crypto.compiler.CryptoCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/crypto-compiler-plugin-@project.version@.jar"

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - Crypto Compiler Plugin Tests'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
+
+    implementation project(':crypto-compiler-plugin')
+
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+
+    testImplementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+sourceCompatibility = JavaVersion.VERSION_21
+
+test {
+    systemProperty "ballerina.offline.flag", "true"
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    testLogging.showStandardStreams = true
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
+spotbugsTest {
+    def classLoader = plugins["com.github.spotbugs"].class.classLoader
+    def SpotBugsConfidence = classLoader.findLoadedClass("com.github.spotbugs.snom.Confidence")
+    def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
+    ignoreFailures = true
+    effort = SpotBugsEffort.MAX
+    reportLevel = SpotBugsConfidence.LOW
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
+    if (excludeFile.exists()) {
+        it.excludeFilter = excludeFile
+    }
+    reports {
+        text.enabled = true
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+tasks.register('validateSpotbugs') {
+    doLast {
+        if (spotbugsMain.reports.size() > 0 &&
+                spotbugsMain.reports[0].destination.exists() &&
+                spotbugsMain.reports[0].destination.text.readLines().size() > 0) {
+            spotbugsMain.reports[0].destination?.eachLine {
+                println 'Failure: ' + it
+            }
+            throw new GradleException("Spotbugs rule violations were found.");
+        }
+    }
+}
+
+tasks.withType(Checkstyle).configureEach {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.checkstylePluginVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain {
+    enabled false
+}
+
+spotbugsTest.finalizedBy validateSpotbugs
+checkstyleTest.dependsOn ':checkstyle:downloadCheckstyleRuleFiles'
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+test.dependsOn ":crypto-ballerina:build"
+build.dependsOn ":crypto-ballerina:build"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/ProcessOutputGobbler.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/ProcessOutputGobbler.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Helper class to consume the process streams.
+ *
+ * @since 2.12.0
+ */
+class ProcessOutputGobbler implements Runnable {
+    private final InputStream inputStream;
+    private final StringBuilder output;
+    private int exitCode;
+
+    public ProcessOutputGobbler(InputStream inputStream) {
+        this.inputStream = inputStream;
+        this.output = new StringBuilder();
+    }
+
+    @Override
+    public void run() {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append("\n");
+            }
+        } catch (IOException e) {
+            this.output.append(e.getMessage());
+        }
+    }
+
+    public String getOutput() {
+        return output.toString();
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public void setExitCode(int exitCode) {
+        this.exitCode = exitCode;
+    }
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.testng.internal.ExitCode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * This class includes tests for Ballerina Http static code analyzer.
+ *
+ * @since 2.15.1
+ */
+public class StaticCodeAnalyzerTest {
+    private static final Path RESOURCE_PACKAGES_DIRECTORY = Paths
+            .get("src", "test", "resources", "static_code_analyzer", "ballerina_packages").toAbsolutePath();
+    private static final Path EXPECTED_JSON_OUTPUT_DIRECTORY = Paths.
+            get("src", "test", "resources", "static_code_analyzer", "expected_output").toAbsolutePath();
+    private static final Path BALLERINA_PATH = getBalCommandPath();
+    private static final Path JSON_RULES_FILE_PATH = Paths
+            .get("../", "compiler-plugin", "src", "main", "resources", "rules.json").toAbsolutePath();
+    private static final String SCAN_COMMAND = "scan";
+
+    private static Path getBalCommandPath() {
+        String balCommand = isWindows() ? "bal.bat" : "bal";
+        return Paths.get("../", "target", "ballerina-runtime", "bin", balCommand).toAbsolutePath();
+    }
+
+    @BeforeSuite
+    public void pullScanTool() throws IOException {
+        ProcessBuilder processBuilder = new ProcessBuilder(BALLERINA_PATH.toString(), "tool", "pull", SCAN_COMMAND);
+        ProcessOutputGobbler output = getOutput(processBuilder.start()).join();
+        if (Pattern.compile("tool 'scan:.+\\..+\\..+' successfully set as the active version\\.")
+                .matcher(output.getOutput()).find() || Pattern.compile("tool 'scan:.+\\..+\\..+' is already active\\.")
+                .matcher(output.getOutput()).find()) {
+            return;
+        }
+        Assert.assertFalse(ExitCode.hasFailure(output.getExitCode()));
+    }
+
+    @Test
+    public void validateRulesJson() throws IOException {
+        String expectedRules = "[" + Arrays.stream(CryptoRule.values())
+                .map(CryptoRule::toString).collect(Collectors.joining(",")) + "]";
+        String actualRules = Files.readString(JSON_RULES_FILE_PATH);
+        assertJsonEqual(normalizeJson(actualRules), normalizeJson(expectedRules));
+    }
+
+    @Test
+    public void testStaticCodeRules() throws IOException {
+        for (CryptoRule rule : CryptoRule.values()) {
+            String targetPackageName = "rule" + rule.getId();
+            String actualJsonReport = StaticCodeAnalyzerTest.executeScanProcess(targetPackageName);
+            String expectedJsonReport = Files
+                    .readString(EXPECTED_JSON_OUTPUT_DIRECTORY.resolve(targetPackageName + ".json"));
+            assertJsonEqual(actualJsonReport, expectedJsonReport);
+        }
+    }
+
+    private static String executeScanProcess(String targetPackage) throws IOException {
+        ProcessBuilder processBuilder = new ProcessBuilder(BALLERINA_PATH.toString(), SCAN_COMMAND);
+        processBuilder.directory(RESOURCE_PACKAGES_DIRECTORY.resolve(targetPackage).toFile());
+        ProcessOutputGobbler output = getOutput(processBuilder.start()).join();
+        Assert.assertFalse(ExitCode.hasFailure(output.getExitCode()));
+        return Files.readString(RESOURCE_PACKAGES_DIRECTORY.resolve(targetPackage)
+                .resolve("target").resolve("report").resolve("scan_results.json"));
+    }
+
+    private static CompletableFuture<ProcessOutputGobbler> getOutput(Process process) {
+        ProcessOutputGobbler outputGobbler = new ProcessOutputGobbler(process.getInputStream());
+        ProcessOutputGobbler errorGobbler = new ProcessOutputGobbler(process.getErrorStream());
+        Thread outputThread = new Thread(outputGobbler);
+        Thread errorThread = new Thread(errorGobbler);
+        outputThread.start();
+        errorThread.start();
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                int exitCode = process.waitFor();
+                outputGobbler.setExitCode(exitCode);
+                errorGobbler.setExitCode(exitCode);
+                outputThread.join();
+                errorThread.join();
+                return outputGobbler;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void assertJsonEqual(String actual, String expected) {
+        Assert.assertEquals(normalizeJson(actual), normalizeJson(expected));
+    }
+
+    private static String normalizeJson(String json) {
+        String normalizedJson = json.replaceAll("\\s*\"\\s*", "\"")
+                .replaceAll("\\s*:\\s*", ":")
+                .replaceAll("\\s*,\\s*", ",")
+                .replaceAll("\\s*\\{\\s*", "{")
+                .replaceAll("\\s*}\\s*", "}")
+                .replaceAll("\\s*\\[\\s*", "[")
+                .replaceAll("\\s*]\\s*", "]")
+                .replaceAll("\n", "")
+                .replaceAll(":\".*module-ballerina-jwt", ":\"module-ballerina-jwt");
+        return isWindows() ? normalizedJson.replaceAll("/", "\\\\\\\\") : normalizedJson;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule1"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal
@@ -1,0 +1,16 @@
+import ballerina/crypto;
+import ballerina/random;
+
+public function aesCbc() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] initialVector = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check crypto:encryptAesCbc(data, key, initialVector);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal
@@ -1,0 +1,16 @@
+import ballerina/crypto as c;
+import ballerina/random;
+
+public function aesCbcAsImport() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] initialVector = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check c:encryptAesCbc(data, key, initialVector);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal
@@ -1,0 +1,12 @@
+import ballerina/crypto;
+import ballerina/random;
+
+public function aesEcb() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check crypto:encryptAesEcb(data, key);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal
@@ -1,0 +1,12 @@
+import ballerina/crypto as c;
+import ballerina/random;
+
+public function aesEcbAsImport() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check c:encryptAesEcb(data, key);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
@@ -1,0 +1,82 @@
+[
+  {
+    "location": {
+      "filePath": "aes_cbc.bal",
+      "startLine": 3,
+      "endLine": 15,
+      "startColumn": 0,
+      "endColumn": 1,
+      "startOffset": 54,
+      "length": 570
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_cbc.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_cbc.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb.bal",
+      "startLine": 3,
+      "endLine": 11,
+      "startColumn": 0,
+      "endColumn": 1,
+      "startOffset": 54,
+      "length": 360
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_ecb.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc.bal",
+      "startLine": 14,
+      "endLine": 14,
+      "startColumn": 21,
+      "endColumn": 67,
+      "startOffset": 574,
+      "length": 46
+    },
+    "rule": {
+      "id": "ballerina\\crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_cbc.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_cbc.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb.bal",
+      "startLine": 10,
+      "endLine": 10,
+      "startColumn": 21,
+      "endColumn": 52,
+      "startOffset": 379,
+      "length": 31
+    },
+    "rule": {
+      "id": "ballerina\\crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_ecb.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
@@ -21,6 +21,26 @@
   },
   {
     "location": {
+      "filePath": "aes_cbc_as_import.bal",
+      "startLine": 3,
+      "endLine": 15,
+      "startColumn": 0,
+      "endColumn": 1,
+      "startOffset": 59,
+      "length": 573
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_cbc_as_import.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_cbc_as_import.bal"
+  },
+  {
+    "location": {
       "filePath": "aes_ecb.bal",
       "startLine": 3,
       "endLine": 11,
@@ -38,6 +58,26 @@
     "source": "BUILT_IN",
     "fileName": "rule1\\aes_ecb.bal",
     "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb_as_import.bal",
+      "startLine": 3,
+      "endLine": 11,
+      "startColumn": 0,
+      "endColumn": 1,
+      "startOffset": 59,
+      "length": 363
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_ecb_as_import.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb_as_import.bal"
   },
   {
     "location": {
@@ -61,6 +101,26 @@
   },
   {
     "location": {
+      "filePath": "aes_cbc_as_import.bal",
+      "startLine": 14,
+      "endLine": 14,
+      "startColumn": 21,
+      "endColumn": 62,
+      "startOffset": 587,
+      "length": 41
+    },
+    "rule": {
+      "id": "ballerina\\crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_cbc_as_import.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_cbc_as_import.bal"
+  },
+  {
+    "location": {
       "filePath": "aes_ecb.bal",
       "startLine": 10,
       "endLine": 10,
@@ -78,5 +138,25 @@
     "source": "BUILT_IN",
     "fileName": "rule1\\aes_ecb.bal",
     "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb_as_import.bal",
+      "startLine": 10,
+      "endLine": 10,
+      "startColumn": 21,
+      "endColumn": 47,
+      "startOffset": 392,
+      "length": 26
+    },
+    "rule": {
+      "id": "ballerina\\crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1\\aes_ecb_as_import.bal",
+    "filePath": "C:\\Users\\nureka\\Documents\\GitHub\\module-ballerina-crypto\\compiler-plugin-tests\\src\\test\\resources\\static_code_analyzer\\ballerina_packages\\rule1\\aes_ecb_as_import.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Crypto compiler plugin test suite" parallel="false">
+
+    <test name="Crypto Compiler Plugin Tests" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.StaticCodeAnalyzerTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - Crypto Compiler Plugin'
+
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
+
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    implementation group: 'io.ballerina.scan', name: 'scan-command', version: "${balScanVersion}"
+    implementation project(":crypto-native")
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle).configureEach {
+    exclude excludePattern
+}
+
+checkstyle {
+    toolVersion "${project.checkstylePluginVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
+
+spotbugsMain {
+    def classLoader = plugins["com.github.spotbugs"].class.classLoader
+    def SpotBugsConfidence = classLoader.findLoadedClass("com.github.spotbugs.snom.Confidence")
+    def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
+    effort = SpotBugsEffort.MAX
+    reportLevel = SpotBugsConfidence.LOW
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if (excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+build.dependsOn ":crypto-native:build"

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler;
+
+/**
+ * JWT compiler plugin.
+ */
+public class CryptoCompilerPlugin {
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
@@ -18,9 +18,24 @@
 
 package io.ballerina.stdlib.crypto.compiler;
 
-/**
- * JWT compiler plugin.
- */
-public class CryptoCompilerPlugin {
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.scan.ScannerContext;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoCodeAnalyzer;
 
+/**
+ * Crypto compiler plugin.
+ *
+ * @since 2.9.1
+ */
+public class CryptoCompilerPlugin extends CompilerPlugin {
+    private static final String SCANNER_CONTEXT = "ScannerContext";
+
+    @Override
+    public void init(CompilerPluginContext context) {
+        Object object = context.userData().get(SCANNER_CONTEXT);
+        if (object instanceof ScannerContext scannerContext) {
+            context.addCodeAnalyzer(new CryptoCodeAnalyzer(scannerContext.getReporter()));
+        }
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+public class CryptoCipherAlgorithmAnalyzer {
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
@@ -18,6 +18,85 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoCipherAlgorithmAnalyzer {
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.scan.Reporter;
 
+/**
+ * Analyzes the syntax tree for function calls to crypto module functions and checks for weak cipher algorithms.
+ * It reports issues related to the use of weak cipher algorithms.
+ */
+public class CryptoCipherAlgorithmAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    private final Reporter reporter;
+    private static final String CRYPTO = "crypto";
+    private static final String ENCRYPT_AES_ECB = "encryptAesEcb";
+    private static final String ENCRYPT_AES_CBC = "encryptAesCbc";
+
+    public CryptoCipherAlgorithmAnalyzer(Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    /**
+     * Analyzes the syntax tree for function calls to crypto module functions.
+     *
+     * @param context the syntax node analysis context
+     */
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        FunctionCallExpressionNode functionCall = (FunctionCallExpressionNode) context.node();
+
+        if (!(functionCall.functionName() instanceof QualifiedNameReferenceNode qualifiedName)) {
+            return;
+        }
+
+        if (!CRYPTO.equals(qualifiedName.modulePrefix().text())) {
+            return;
+        }
+
+        String functionName = qualifiedName.identifier().text();
+
+        if (isWeakCipherFunction(functionName)) {
+            report(context, CryptoRule.AVOID_WEAK_CIPHER_ALGORITHMS.getId());
+        }
+    }
+
+    /**
+     * Checks if the given function name corresponds to a weak cipher function.
+     *
+     * @param functionName the name of the function
+     * @return true if the function is a weak cipher function, false otherwise
+     */
+    private boolean isWeakCipherFunction(String functionName) {
+        return ENCRYPT_AES_ECB.equals(functionName) || ENCRYPT_AES_CBC.equals(functionName);
+    }
+
+    /**
+     * Reports an issue for the given context and rule ID.
+     *
+     * @param context the syntax node analysis context
+     * @param ruleId  the ID of the rule to report
+     */
+    private void report(SyntaxNodeAnalysisContext context, int ruleId) {
+        reporter.reportIssue(
+                getDocument(context.currentPackage().module(context.moduleId()), context.documentId()),
+                context.node().location(),
+                ruleId
+        );
+    }
+
+    /**
+     * Retrieves the Document corresponding to the given module and document ID.
+     *
+     * @param module     the module
+     * @param documentId the document ID
+     * @return the Document for the given module and document ID
+     */
+    private static Document getDocument(Module module, DocumentId documentId) {
+        return module.document(documentId);
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
@@ -19,6 +19,9 @@
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImportOrgNameNode;
+import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
@@ -26,6 +29,9 @@ import io.ballerina.projects.Module;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.scan.Reporter;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Analyzes the syntax tree for function calls to crypto module functions and checks for weak cipher algorithms.
@@ -36,9 +42,13 @@ public class CryptoCipherAlgorithmAnalyzer implements AnalysisTask<SyntaxNodeAna
     private static final String CRYPTO = "crypto";
     private static final String ENCRYPT_AES_ECB = "encryptAesEcb";
     private static final String ENCRYPT_AES_CBC = "encryptAesCbc";
+    private static final String BALLERINA_ORG = "ballerina";
+
+    private Set<String> cryptoPrefixes = new HashSet<>();
 
     public CryptoCipherAlgorithmAnalyzer(Reporter reporter) {
         this.reporter = reporter;
+        this.cryptoPrefixes.add(CRYPTO);
     }
 
     /**
@@ -48,13 +58,17 @@ public class CryptoCipherAlgorithmAnalyzer implements AnalysisTask<SyntaxNodeAna
      */
     @Override
     public void perform(SyntaxNodeAnalysisContext context) {
+        analyzeImports(context);
+
         FunctionCallExpressionNode functionCall = (FunctionCallExpressionNode) context.node();
 
         if (!(functionCall.functionName() instanceof QualifiedNameReferenceNode qualifiedName)) {
             return;
         }
 
-        if (!CRYPTO.equals(qualifiedName.modulePrefix().text())) {
+        String modulePrefix = qualifiedName.modulePrefix().text();
+
+        if (!cryptoPrefixes.contains(modulePrefix)) {
             return;
         }
 
@@ -98,5 +112,31 @@ public class CryptoCipherAlgorithmAnalyzer implements AnalysisTask<SyntaxNodeAna
      */
     private static Document getDocument(Module module, DocumentId documentId) {
         return module.document(documentId);
+    }
+
+    /**
+     * Analyzes imports to identify all prefixes used for the crypto module.
+     *
+     * @param context the syntax node analysis context
+     */
+    private void analyzeImports(SyntaxNodeAnalysisContext context) {
+        Document document = getDocument(context.currentPackage().module(context.moduleId()), context.documentId());
+
+        if (document.syntaxTree().rootNode() instanceof ModulePartNode modulePartNode) {
+            modulePartNode.imports().forEach(importDeclarationNode -> {
+                ImportOrgNameNode importOrgNameNode = importDeclarationNode.orgName().orElse(null);
+
+                if (importOrgNameNode != null && BALLERINA_ORG.equals(importOrgNameNode.orgName().text())
+                        && importDeclarationNode.moduleName().stream()
+                        .anyMatch(moduleNameNode -> CRYPTO.equals(moduleNameNode.text()))) {
+
+                    ImportPrefixNode importPrefixNode = importDeclarationNode.prefix().orElse(null);
+                    String prefix = importPrefixNode != null ? importPrefixNode.prefix().text() : CRYPTO;
+
+                    cryptoPrefixes.add(prefix);
+                }
+
+            });
+        }
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
@@ -18,6 +18,21 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoCodeAnalyzer {
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.scan.Reporter;
 
+public class CryptoCodeAnalyzer extends CodeAnalyzer {
+    private final Reporter reporter;
+
+    public CryptoCodeAnalyzer(Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new CryptoCipherAlgorithmAnalyzer(reporter),
+                SyntaxKind.FUNCTION_CALL);
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+public class CryptoCodeAnalyzer {
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+public class CryptoRule {
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
@@ -18,5 +18,36 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoRule {
+import io.ballerina.scan.Rule;
+
+import static io.ballerina.scan.RuleKind.VULNERABILITY;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.RuleFactory.createRule;
+
+public enum CryptoRule {
+    AVOID_WEAK_CIPHER_ALGORITHMS(createRule(
+            1,
+            "Encryption algorithms should be used with"
+                    + " secure mode and padding scheme",
+            VULNERABILITY)
+    );
+
+    private final Rule rule;
+
+    CryptoRule(Rule rule) {
+        this.rule = rule;
+    }
+
+    public int getId() {
+        return this.rule.numericId();
+    }
+
+    public Rule getRule() {
+        return this.rule;
+    }
+
+    @Override
+    public String toString() {
+        return "{\"id\":" + this.getId() + ", \"kind\":\"" + this.rule.kind() + "\"," +
+                " \"description\" : \"" + this.rule.description() + "\"}";
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/RuleFactory.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/RuleFactory.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+import io.ballerina.scan.Rule;
+import io.ballerina.scan.RuleKind;
+
+/**
+ * {@code RuleFactory} contains the logic to create a {@link Rule}.
+ */
+public class RuleFactory {
+
+    private RuleFactory() {
+    }
+
+    public static Rule createRule(int id, String description, RuleKind kind) {
+        return new RuleImpl(id, description, kind);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/RuleImpl.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/RuleImpl.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+import io.ballerina.scan.Rule;
+import io.ballerina.scan.RuleKind;
+
+public class RuleImpl implements Rule {
+    private final int id;
+    private final String description;
+    private final RuleKind kind;
+
+    RuleImpl(int id, String description, RuleKind kind) {
+        this.id = id;
+        this.description = description;
+        this.kind = kind;
+    }
+
+    @Override
+    public String id() {
+        return Integer.toString(this.id);
+    }
+
+    @Override
+    public int numericId() {
+        return this.id;
+    }
+
+    @Override
+    public String description() {
+        return this.description;
+    }
+
+    @Override
+    public RuleKind kind() {
+        return this.kind;
+    }
+}

--- a/compiler-plugin/src/main/java/module-info.java
+++ b/compiler-plugin/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  OF ANY KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+module io.ballerina.stdlib.crypto.compiler {
+    requires io.ballerina.lang;
+    requires io.ballerina.tools.api;
+    requires io.ballerina.parser;
+    requires io.ballerina.scan;
+}

--- a/compiler-plugin/src/main/resources/rules.json
+++ b/compiler-plugin/src/main/resources/rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "kind": "VULNERABILITY",
+    "description": "Encryption algorithms should be used with secure mode and padding scheme"
+  }
+]

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,7 @@ nativeImageVersion=22.2.0
 ballerinaLangVersion=2201.12.0
 stdlibTimeVersion=2.7.0
 stdlibIoVersion=1.8.0
+
+testngVersion=7.6.1
+gsonVersion=2.7
+balScanVersion=0.9.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,10 +37,14 @@ rootProject.name = 'crypto'
 include ':checkstyle'
 include ':crypto-native'
 include ':crypto-ballerina'
+include ':crypto-compiler-plugin'
+include ':crypto-compiler-plugin-tests'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':crypto-native').projectDir = file('native')
 project(':crypto-ballerina').projectDir = file('ballerina')
+project(':crypto-compiler-plugin').projectDir = file('compiler-plugin')
+project(':crypto-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
Fixes https://github.com/ballerina-platform/ballerina-library/issues/7940

## Description

1. The analyzer is triggered when a `FUNCTION_CALL` node is encountered in the syntax tree.

2. It checks for a `QualifiedNameReferenceNode` with any prefixes used for the crypto module (both default `crypto` and any custom prefixes) and identifier `encryptAesEcb` or `encryptAesCbc`.

3. On match, the analyzer reports the vulnerability.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
