### PR TITLE
Implement static code analysis rule to analyse weak encryption algorithm usage

### DIFF
--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    testImplementation group: 'io.ballerina.scan', name: 'scan-command', version: "${balScanVersion}"
+    testImplementation group: 'io.ballerina.scan', name: 'scan-command-test-utils', version: "${balScanVersion}"
 
     testImplementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
+
+import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.scan.Issue;
+import io.ballerina.scan.Rule;
+import io.ballerina.scan.RuleKind;
+import io.ballerina.scan.Source;
+import io.ballerina.scan.test.Assertions;
+import io.ballerina.scan.test.TestOptions;
+import io.ballerina.scan.test.TestRunner;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public class StaticCodeAnalyzerTest {
+    private static final Path RESOURCE_PACKAGES_DIRECTORY = Paths
+            .get("src", "test", "resources", "static_code_analyzer", "ballerina_packages").toAbsolutePath();
+    private static final Path EXPECTED_OUTPUT_DIRECTORY = Paths
+            .get("src", "test", "resources", "static_code_analyzer", "expected_output").toAbsolutePath();
+    private static final Path JSON_RULES_FILE_PATH = Paths
+            .get("../", "compiler-plugin", "src", "main", "resources", "rules.json").toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime");
+
+    @Test
+    public void validateRulesJson() throws IOException {
+        String expectedRules = "[" + Arrays.stream(CryptoRule.values())
+                .map(CryptoRule::toString).collect(Collectors.joining(",")) + "]";
+        String actualRules = Files.readString(JSON_RULES_FILE_PATH);
+        assertJsonEqual(actualRules, expectedRules);
+    }
+
+    @Test
+    public void testStaticCodeRulesWithAPI() throws IOException {
+        ByteArrayOutputStream console = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(console);
+        for (CryptoRule rule : CryptoRule.values()) {
+            String targetPackageName = "rule" + rule.getId();
+            Path targetPackagePath = RESOURCE_PACKAGES_DIRECTORY.resolve(targetPackageName);
+            Project project = BuildProject.load(getEnvironmentBuilder(), targetPackagePath);
+            TestOptions options = TestOptions.builder(project)
+                    .setOutputStream(printStream)
+                    .build();
+            TestRunner testRunner = new TestRunner(options);
+            testRunner.performScan();
+
+            // validate the Crypto rules
+            List<Rule> rules = testRunner.getRules();
+            Assertions.assertRule(
+                    rules,
+                    "ballerina/crypto:1",
+                    "Encryption algorithms should be used with secure mode and padding scheme",
+                    RuleKind.VULNERABILITY);
+
+            // validate the issues
+            List<Issue> issues = testRunner.getIssues();
+            Assert.assertEquals(issues.size(), 4);
+            Assertions.assertIssue(issues, 0, "ballerina/crypto:1", "aes_cbc.bal",
+                    30, 30, Source.BUILT_IN);
+            Assertions.assertIssue(issues, 1, "ballerina/crypto:1", "aes_cbc_as_import.bal",
+                    30, 30, Source.BUILT_IN);
+            Assertions.assertIssue(issues, 2, "ballerina/crypto:1", "aes_ecb.bal",
+                    26, 26, Source.BUILT_IN);
+            Assertions.assertIssue(issues, 3, "ballerina/crypto:1", "aes_ecb_as_import.bal",
+                    26, 26, Source.BUILT_IN);
+
+            // validate the output
+            String output = console.toString();
+            String jsonOutput = extractJson(output);
+            String expectedOutput = Files.readString(EXPECTED_OUTPUT_DIRECTORY.resolve(targetPackageName
+                    + ".json"));
+            assertJsonEqual(jsonOutput, expectedOutput);
+        }
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private String extractJson(String consoleOutput) {
+        int startIndex = consoleOutput.indexOf("[");
+        int endIndex = consoleOutput.lastIndexOf("]");
+        if (startIndex == -1 || endIndex == -1) {
+            return "";
+        }
+        return consoleOutput.substring(startIndex, endIndex + 1);
+    }
+
+    private void assertJsonEqual(String actual, String expected) {
+        Assert.assertEquals(normalizeString(actual), normalizeString(expected));
+    }
+
+    private static String normalizeString(String json) {
+        String normalizedJson = json.replaceAll("\\s*\"\\s*", "\"")
+                .replaceAll("\\s*:\\s*", ":")
+                .replaceAll("\\s*,\\s*", ",")
+                .replaceAll("\\s*\\{\\s*", "{")
+                .replaceAll("\\s*}\\s*", "}")
+                .replaceAll("\\s*\\[\\s*", "[")
+                .replaceAll("\\s*]\\s*", "]")
+                .replaceAll("\n", "")
+                .replaceAll(":\".*module-ballerina-crypto", ":\"module-ballerina-crypto");
+        return isWindows() ? normalizedJson.replaceAll("/", "\\\\\\\\") : normalizedJson;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).startsWith("windows");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule1"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+import ballerina/random;
+
+public function aesCbc() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] initialVector = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check crypto:encryptAesCbc(data, key, initialVector);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto as c;
+import ballerina/random;
+
+public function aesCbcAsImport() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] initialVector = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check c:encryptAesCbc(data, key, initialVector);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+import ballerina/random;
+
+public function aesEcb() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check crypto:encryptAesEcb(data, key);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto as c;
+import ballerina/random;
+
+public function aesEcbAsImport() returns error? {
+    string dataString = "Hello Ballerina!";
+    byte[] data = dataString.toBytes();
+    byte[16] key = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    foreach int i in 0 ... 15 {
+        key[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check c:encryptAesEcb(data, key);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
@@ -1,0 +1,162 @@
+[
+  {
+    "location": {
+      "filePath": "aes_cbc.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 0,
+      "endColumn": 6,
+      "startOffset": 694,
+      "length": 6
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc_as_import.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 0,
+      "endColumn": 6,
+      "startOffset": 699,
+      "length": 6
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc_as_import.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 0,
+      "endColumn": 6,
+      "startOffset": 694,
+      "length": 6
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_ecb.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb_as_import.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 0,
+      "endColumn": 6,
+      "startOffset": 699,
+      "length": 6
+    },
+    "rule": {
+      "id": "ballerina:3",
+      "numericId": 3,
+      "description": "Non isolated public function",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_ecb_as_import.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc.bal",
+      "startLine": 30,
+      "endLine": 30,
+      "startColumn": 21,
+      "endColumn": 67,
+      "startOffset": 1203,
+      "length": 46
+    },
+    "rule": {
+      "id": "ballerina/crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc_as_import.bal",
+      "startLine": 30,
+      "endLine": 30,
+      "startColumn": 21,
+      "endColumn": 62,
+      "startOffset": 1216,
+      "length": 41
+    },
+    "rule": {
+      "id": "ballerina/crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc_as_import.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb.bal",
+      "startLine": 26,
+      "endLine": 26,
+      "startColumn": 21,
+      "endColumn": 52,
+      "startOffset": 1012,
+      "length": 31
+    },
+    "rule": {
+      "id": "ballerina/crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_ecb.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_ecb_as_import.bal",
+      "startLine": 26,
+      "endLine": 26,
+      "startColumn": 21,
+      "endColumn": 47,
+      "startOffset": 1025,
+      "length": 26
+    },
+    "rule": {
+      "id": "ballerina/crypto:1",
+      "numericId": 1,
+      "description": "Encryption algorithms should be used with secure mode and padding scheme",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_ecb_as_import.bal",
+    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Crypto compiler plugin test suite" parallel="false">
+
+    <test name="Crypto Compiler Plugin Tests" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.StaticCodeAnalyzerTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/CryptoCompilerPlugin.java
@@ -18,11 +18,24 @@
 
 package io.ballerina.stdlib.crypto.compiler;
 
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.scan.ScannerContext;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoCodeAnalyzer;
+
 /**
  * Crypto compiler plugin.
  *
  * @since 2.9.1
  */
-public class CryptoCompilerPlugin {
+public class CryptoCompilerPlugin extends CompilerPlugin {
+    private static final String SCANNER_CONTEXT = "ScannerContext";
 
+    @Override
+    public void init(CompilerPluginContext context) {
+        Object object = context.userData().get(SCANNER_CONTEXT);
+        if (object instanceof ScannerContext scannerContext) {
+            context.addCodeAnalyzer(new CryptoCodeAnalyzer(scannerContext.getReporter()));
+        }
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCipherAlgorithmAnalyzer.java
@@ -18,6 +18,122 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoCipherAlgorithmAnalyzer {
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImportOrgNameNode;
+import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.scan.Reporter;
 
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Analyzes the syntax tree for function calls to crypto module functions and checks for weak cipher algorithms.
+ */
+public class CryptoCipherAlgorithmAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    private final Reporter reporter;
+    private static final String CRYPTO = "crypto";
+    private static final String ENCRYPT_AES_ECB = "encryptAesEcb";
+    private static final String ENCRYPT_AES_CBC = "encryptAesCbc";
+    private static final String BALLERINA_ORG = "ballerina";
+    private final Set<String> cryptoPrefixes = new HashSet<>();
+
+    public CryptoCipherAlgorithmAnalyzer(Reporter reporter) {
+        this.reporter = reporter;
+        this.cryptoPrefixes.add(CRYPTO);
+    }
+
+    /**
+     * Analyzes the syntax tree for function calls to crypto module functions.
+     *
+     * @param context the syntax node analysis context
+     */
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        analyzeImports(context);
+
+        FunctionCallExpressionNode functionCall = (FunctionCallExpressionNode) context.node();
+
+        if (!(functionCall.functionName() instanceof QualifiedNameReferenceNode qualifiedName)) {
+            return;
+        }
+
+        String modulePrefix = qualifiedName.modulePrefix().text();
+
+        if (!cryptoPrefixes.contains(modulePrefix)) {
+            return;
+        }
+
+        String functionName = qualifiedName.identifier().text();
+
+        if (isWeakCipherFunction(functionName)) {
+            report(context, CryptoRule.AVOID_WEAK_CIPHER_ALGORITHMS.getId());
+        }
+    }
+
+    /**
+     * Checks if the given function name corresponds to a weak cipher function.
+     *
+     * @param functionName the name of the function
+     * @return true if the function is a weak cipher function, false otherwise
+     */
+    private boolean isWeakCipherFunction(String functionName) {
+        return ENCRYPT_AES_ECB.equals(functionName) || ENCRYPT_AES_CBC.equals(functionName);
+    }
+
+    /**
+     * Reports an issue for the given context and rule ID.
+     *
+     * @param context the syntax node analysis context
+     * @param ruleId  the ID of the rule to report
+     */
+    private void report(SyntaxNodeAnalysisContext context, int ruleId) {
+        reporter.reportIssue(
+                getDocument(context.currentPackage().module(context.moduleId()), context.documentId()),
+                context.node().location(),
+                ruleId
+        );
+    }
+
+    /**
+     * Retrieves the Document corresponding to the given module and document ID.
+     *
+     * @param module     the module
+     * @param documentId the document ID
+     * @return the Document for the given module and document ID
+     */
+    private static Document getDocument(Module module, DocumentId documentId) {
+        return module.document(documentId);
+    }
+
+    /**
+     * Analyzes imports to identify all prefixes used for the crypto module.
+     *
+     * @param context the syntax node analysis context
+     */
+    private void analyzeImports(SyntaxNodeAnalysisContext context) {
+        Document document = getDocument(context.currentPackage().module(context.moduleId()), context.documentId());
+
+        if (document.syntaxTree().rootNode() instanceof ModulePartNode modulePartNode) {
+            modulePartNode.imports().forEach(importDeclarationNode -> {
+                ImportOrgNameNode importOrgNameNode = importDeclarationNode.orgName().orElse(null);
+
+                if (importOrgNameNode != null && BALLERINA_ORG.equals(importOrgNameNode.orgName().text())
+                        && importDeclarationNode.moduleName().stream()
+                        .anyMatch(moduleNameNode -> CRYPTO.equals(moduleNameNode.text()))) {
+
+                    ImportPrefixNode importPrefixNode = importDeclarationNode.prefix().orElse(null);
+                    String prefix = importPrefixNode != null ? importPrefixNode.prefix().text() : CRYPTO;
+
+                    cryptoPrefixes.add(prefix);
+                }
+            });
+        }
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoCodeAnalyzer.java
@@ -18,6 +18,21 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoCodeAnalyzer {
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.scan.Reporter;
 
+public class CryptoCodeAnalyzer extends CodeAnalyzer {
+    private final Reporter reporter;
+
+    public CryptoCodeAnalyzer(Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new CryptoCipherAlgorithmAnalyzer(reporter),
+                SyntaxKind.FUNCTION_CALL);
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
@@ -18,5 +18,32 @@
 
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
-public class CryptoRule {
+import io.ballerina.scan.Rule;
+
+import static io.ballerina.scan.RuleKind.VULNERABILITY;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.RuleFactory.createRule;
+
+public enum CryptoRule {
+    AVOID_WEAK_CIPHER_ALGORITHMS(createRule(1, "Encryption algorithms should be used with secure mode " +
+            "and padding scheme", VULNERABILITY));
+
+    private final Rule rule;
+
+    CryptoRule(Rule rule) {
+        this.rule = rule;
+    }
+
+    public int getId() {
+        return this.rule.numericId();
+    }
+
+    public Rule getRule() {
+        return this.rule;
+    }
+
+    @Override
+    public String toString() {
+        return "{\"id\":" + this.getId() + ", \"kind\":\"" + this.rule.kind() + "\"," +
+                " \"description\" : \"" + this.rule.description() + "\"}";
+    }
 }

--- a/compiler-plugin/src/main/resources/rules.json
+++ b/compiler-plugin/src/main/resources/rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "kind": "VULNERABILITY",
+    "description": "Encryption algorithms should be used with secure mode and padding scheme"
+  }
+]

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ stdlibTimeVersion=2.7.0
 stdlibIoVersion=1.8.0
 
 testngVersion=7.6.1
-balScanVersion=0.9.0
+balScanVersion=0.10.0


### PR DESCRIPTION
## Purpose

Fixes https://github.com/ballerina-platform/ballerina-library/issues/7940

## Description

1. The analyzer is triggered when a `FUNCTION_CALL` node is encountered in the syntax tree.

2. It checks for a `QualifiedNameReferenceNode` with any prefixes used for the crypto module (both default `crypto` and any custom prefixes) and identifier `encryptAesEcb` or `encryptAesCbc`.

3. On match, the analyzer reports the vulnerability.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
