### PR TITLE
Add static analysis rule to detect unsecure random number usage

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import static io.ballerina.scan.RuleKind.VULNERABILITY;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_FAST_HASH_ALGORITHMS;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_REUSING_COUNTER_MODE_VECTORS;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_USING_UNSECURE_RANDOM_NUMBER_GENERATORS;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_CIPHER_ALGORITHMS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -117,19 +118,28 @@ public class StaticCodeAnalyzerTest {
                 "ballerina/crypto:3",
                 AVOID_REUSING_COUNTER_MODE_VECTORS.getDescription(),
                 VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:4",
+                AVOID_USING_UNSECURE_RANDOM_NUMBER_GENERATORS.getDescription(),
+                VULNERABILITY);
     }
 
     private void validateIssues(CryptoRule rule, List<Issue> issues) {
         switch (rule) {
             case AVOID_WEAK_CIPHER_ALGORITHMS:
-                Assert.assertEquals(issues.size(), 4);
+                Assert.assertEquals(issues.size(), 6);
                 Assertions.assertIssue(issues, 0, "ballerina/crypto:1", "aes_cbc.bal",
                         30, 30, Source.BUILT_IN);
-                Assertions.assertIssue(issues, 1, "ballerina/crypto:1", "aes_cbc_as_import.bal",
+                Assertions.assertIssue(issues, 1, "ballerina/crypto:4", "aes_cbc.bal",
                         30, 30, Source.BUILT_IN);
-                Assertions.assertIssue(issues, 2, "ballerina/crypto:1", "aes_ecb.bal",
+                Assertions.assertIssue(issues, 2, "ballerina/crypto:1", "aes_cbc_as_import.bal",
+                        30, 30, Source.BUILT_IN);
+                Assertions.assertIssue(issues, 3, "ballerina/crypto:4", "aes_cbc_as_import.bal",
+                        30, 30, Source.BUILT_IN);
+                Assertions.assertIssue(issues, 4, "ballerina/crypto:1", "aes_ecb.bal",
                         26, 26, Source.BUILT_IN);
-                Assertions.assertIssue(issues, 3, "ballerina/crypto:1", "aes_ecb_as_import.bal",
+                Assertions.assertIssue(issues, 5, "ballerina/crypto:1", "aes_ecb_as_import.bal",
                         26, 26, Source.BUILT_IN);
                 break;
             case AVOID_FAST_HASH_ALGORITHMS:
@@ -185,6 +195,11 @@ public class StaticCodeAnalyzerTest {
                         23, 23, Source.BUILT_IN);
                 Assertions.assertIssue(issues, 5, "ballerina/crypto:3", "mod_var_pos_arg.bal",
                         23, 23, Source.BUILT_IN);
+                break;
+            case AVOID_USING_UNSECURE_RANDOM_NUMBER_GENERATORS:
+                Assert.assertEquals(issues.size(), 1);
+                Assertions.assertIssue(issues, 0, "ballerina/crypto:4", "main.bal",
+                        27, 27, Source.BUILT_IN);
                 break;
             default:
                 Assert.fail("Unhandled rule in validateIssues: " + rule);

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule4"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/main.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/main.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+import ballerina/random;
+
+public isolated function main() returns error? {
+    string data = "Hello, World!";
+    byte[16] initialVector = [];
+    byte[16] key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    byte[] dataBytes = data.toBytes();
+    foreach int i in 0 ... 15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[] _ = check crypto:encryptAesGcm(dataBytes, key, initialVector);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc_as_import.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
   },
   {
     "location": {
@@ -57,7 +57,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
   },
   {
     "location": {
@@ -77,7 +77,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb_as_import.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
   },
   {
     "location": {
@@ -97,7 +97,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
   },
   {
     "location": {
@@ -117,7 +117,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
   },
   {
     "location": {
@@ -137,7 +137,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc_as_import.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
   },
   {
     "location": {
@@ -157,7 +157,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc_as_import.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
   },
   {
     "location": {
@@ -177,7 +177,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
   },
   {
     "location": {
@@ -197,6 +197,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb_as_import.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule1.json
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc_as_import.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
   },
   {
     "location": {
@@ -57,7 +57,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
   },
   {
     "location": {
@@ -77,7 +77,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb_as_import.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
   },
   {
     "location": {
@@ -97,7 +97,27 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc.bal",
+      "startLine": 30,
+      "endLine": 30,
+      "startColumn": 21,
+      "endColumn": 67,
+      "startOffset": 1203,
+      "length": 46
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Secure random number generators should not output predictable values",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc.bal",
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc.bal"
   },
   {
     "location": {
@@ -117,7 +137,27 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_cbc_as_import.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
+  },
+  {
+    "location": {
+      "filePath": "aes_cbc_as_import.bal",
+      "startLine": 30,
+      "endLine": 30,
+      "startColumn": 21,
+      "endColumn": 62,
+      "startOffset": 1216,
+      "length": 41
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Secure random number generators should not output predictable values",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule1/aes_cbc_as_import.bal",
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_cbc_as_import.bal"
   },
   {
     "location": {
@@ -137,7 +177,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb.bal"
   },
   {
     "location": {
@@ -157,6 +197,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule1/aes_ecb_as_import.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule1/aes_ecb_as_import.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule2.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule2.json
@@ -6,7 +6,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -26,7 +26,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -37,7 +37,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -46,7 +46,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -57,7 +57,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
   },
   {
     "location": {
@@ -66,7 +66,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -77,7 +77,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -86,7 +86,7 @@
       "endLine": 22,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 785,
+      "startOffset": 763,
       "length": 6
     },
     "rule": {
@@ -97,7 +97,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -106,7 +106,7 @@
       "endLine": 22,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 779,
+      "startOffset": 757,
       "length": 6
     },
     "rule": {
@@ -117,7 +117,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -126,7 +126,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -137,7 +137,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -146,7 +146,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -157,7 +157,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -166,7 +166,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -177,7 +177,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
   },
   {
     "location": {
@@ -186,7 +186,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -197,7 +197,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -206,7 +206,7 @@
       "endLine": 20,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 721,
+      "startOffset": 701,
       "length": 6
     },
     "rule": {
@@ -217,7 +217,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -226,7 +226,7 @@
       "endLine": 20,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 719,
+      "startOffset": 699,
       "length": 6
     },
     "rule": {
@@ -237,7 +237,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -246,7 +246,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -257,7 +257,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -266,7 +266,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -277,7 +277,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -286,7 +286,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -297,7 +297,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
   },
   {
     "location": {
@@ -306,7 +306,7 @@
       "endLine": 18,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 687,
+      "startOffset": 669,
       "length": 6
     },
     "rule": {
@@ -317,7 +317,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -326,7 +326,7 @@
       "endLine": 20,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 731,
+      "startOffset": 711,
       "length": 6
     },
     "rule": {
@@ -337,7 +337,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -346,7 +346,7 @@
       "endLine": 20,
       "startColumn": 0,
       "endColumn": 6,
-      "startOffset": 729,
+      "startOffset": 709,
       "length": 6
     },
     "rule": {
@@ -357,7 +357,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -366,7 +366,7 @@
       "endLine": 23,
       "startColumn": 21,
       "endColumn": 117,
-      "startOffset": 880,
+      "startOffset": 857,
       "length": 96
     },
     "rule": {
@@ -377,7 +377,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -386,7 +386,7 @@
       "endLine": 23,
       "startColumn": 21,
       "endColumn": 81,
-      "startOffset": 878,
+      "startOffset": 855,
       "length": 60
     },
     "rule": {
@@ -397,7 +397,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -406,7 +406,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 96,
-      "startOffset": 798,
+      "startOffset": 778,
       "length": 75
     },
     "rule": {
@@ -417,7 +417,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
   },
   {
     "location": {
@@ -426,7 +426,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 60,
-      "startOffset": 796,
+      "startOffset": 776,
       "length": 39
     },
     "rule": {
@@ -437,7 +437,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -446,7 +446,7 @@
       "endLine": 24,
       "startColumn": 21,
       "endColumn": 150,
-      "startOffset": 902,
+      "startOffset": 878,
       "length": 129
     },
     "rule": {
@@ -457,7 +457,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -466,7 +466,7 @@
       "endLine": 24,
       "startColumn": 21,
       "endColumn": 144,
-      "startOffset": 894,
+      "startOffset": 870,
       "length": 123
     },
     "rule": {
@@ -477,7 +477,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -486,7 +486,7 @@
       "endLine": 21,
       "startColumn": 21,
       "endColumn": 73,
-      "startOffset": 831,
+      "startOffset": 810,
       "length": 52
     },
     "rule": {
@@ -497,7 +497,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -506,7 +506,7 @@
       "endLine": 21,
       "startColumn": 21,
       "endColumn": 60,
-      "startOffset": 829,
+      "startOffset": 808,
       "length": 39
     },
     "rule": {
@@ -517,7 +517,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -526,7 +526,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 64,
-      "startOffset": 799,
+      "startOffset": 779,
       "length": 43
     },
     "rule": {
@@ -537,7 +537,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
   },
   {
     "location": {
@@ -546,7 +546,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 51,
-      "startOffset": 797,
+      "startOffset": 777,
       "length": 30
     },
     "rule": {
@@ -557,7 +557,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -566,7 +566,7 @@
       "endLine": 22,
       "startColumn": 21,
       "endColumn": 84,
-      "startOffset": 839,
+      "startOffset": 817,
       "length": 63
     },
     "rule": {
@@ -577,7 +577,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -586,7 +586,7 @@
       "endLine": 22,
       "startColumn": 21,
       "endColumn": 69,
-      "startOffset": 835,
+      "startOffset": 813,
       "length": 48
     },
     "rule": {
@@ -597,7 +597,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -606,7 +606,7 @@
       "endLine": 21,
       "startColumn": 21,
       "endColumn": 73,
-      "startOffset": 835,
+      "startOffset": 814,
       "length": 52
     },
     "rule": {
@@ -617,7 +617,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -626,7 +626,7 @@
       "endLine": 21,
       "startColumn": 21,
       "endColumn": 60,
-      "startOffset": 833,
+      "startOffset": 812,
       "length": 39
     },
     "rule": {
@@ -637,7 +637,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -646,7 +646,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 68,
-      "startOffset": 799,
+      "startOffset": 779,
       "length": 47
     },
     "rule": {
@@ -657,7 +657,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
   },
   {
     "location": {
@@ -666,7 +666,7 @@
       "endLine": 20,
       "startColumn": 21,
       "endColumn": 55,
-      "startOffset": 797,
+      "startOffset": 777,
       "length": 34
     },
     "rule": {
@@ -677,7 +677,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -686,7 +686,7 @@
       "endLine": 22,
       "startColumn": 21,
       "endColumn": 90,
-      "startOffset": 849,
+      "startOffset": 827,
       "length": 69
     },
     "rule": {
@@ -697,7 +697,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_named_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -706,7 +706,7 @@
       "endLine": 22,
       "startColumn": 21,
       "endColumn": 75,
-      "startOffset": 845,
+      "startOffset": 823,
       "length": 54
     },
     "rule": {
@@ -717,6 +717,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_pos_arg.bal",
-    "filePath": "C:/Users/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule2.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule2.json
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -57,7 +57,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
   },
   {
     "location": {
@@ -77,7 +77,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -97,7 +97,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -117,7 +117,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -137,7 +137,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -157,7 +157,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -177,7 +177,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
   },
   {
     "location": {
@@ -197,7 +197,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -217,7 +217,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -237,7 +237,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -257,7 +257,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -277,7 +277,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -297,7 +297,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
   },
   {
     "location": {
@@ -317,7 +317,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -337,7 +337,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -357,7 +357,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -377,7 +377,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -397,7 +397,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -417,7 +417,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_named_arg.bal"
   },
   {
     "location": {
@@ -437,7 +437,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -457,7 +457,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -477,7 +477,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/argon_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/argon_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -497,7 +497,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -517,7 +517,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -537,7 +537,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_named_arg.bal"
   },
   {
     "location": {
@@ -557,7 +557,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -577,7 +577,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -597,7 +597,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/bcrypt_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/bcrypt_mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -617,7 +617,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_named_arg.bal"
   },
   {
     "location": {
@@ -637,7 +637,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -657,7 +657,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_named_arg.bal"
   },
   {
     "location": {
@@ -677,7 +677,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_inline_pos_arg.bal"
   },
   {
     "location": {
@@ -697,7 +697,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -717,6 +717,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule2/pbkdf2_mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule2/pbkdf2_mod_var_pos_arg.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule3.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule3.json
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_named_arg.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -57,7 +57,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_named_arg.bal"
   },
   {
     "location": {
@@ -77,7 +77,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_pos_arg.bal"
   },
   {
     "location": {
@@ -97,7 +97,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -117,7 +117,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_pos_arg.bal"
   },
   {
     "location": {
@@ -137,7 +137,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/func_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_named_arg.bal"
   },
   {
     "location": {
@@ -157,7 +157,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/func_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_var_pos_arg.bal"
   },
   {
     "location": {
@@ -177,7 +177,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/inline_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_named_arg.bal"
   },
   {
     "location": {
@@ -197,7 +197,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/inline_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/inline_pos_arg.bal"
   },
   {
     "location": {
@@ -217,7 +217,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/mod_var_named_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_named_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_named_arg.bal"
   },
   {
     "location": {
@@ -237,6 +237,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule3/mod_var_pos_arg.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_pos_arg.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/mod_var_pos_arg.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
@@ -1,0 +1,22 @@
+[
+  {
+    "location": {
+      "filePath": "main.bal",
+      "startLine": 27,
+      "endLine": 27,
+      "startColumn": 21,
+      "endColumn": 72,
+      "startOffset": 1058,
+      "length": 51
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Secure random number generators should not output predictable values",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/main.bal",
+    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/main.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "rule4/main.bal",
-    "filePath": "/home/nureka/Documents/GitHub/module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/main.bal"
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/main.bal"
   }
 ]

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
@@ -24,10 +24,14 @@ import static io.ballerina.scan.RuleKind.VULNERABILITY;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.RuleFactory.createRule;
 
 public enum CryptoRule {
-    AVOID_WEAK_CIPHER_ALGORITHMS(createRule(1, "Avoid using insecure cipher modes or padding schemes", VULNERABILITY)),
-    AVOID_FAST_HASH_ALGORITHMS(createRule(2, "Avoid using fast hashing algorithms", VULNERABILITY)),
+    AVOID_WEAK_CIPHER_ALGORITHMS(createRule(1,
+            "Avoid using insecure cipher modes or padding schemes", VULNERABILITY)),
+    AVOID_FAST_HASH_ALGORITHMS(createRule(2,
+            "Avoid using fast hashing algorithms", VULNERABILITY)),
     AVOID_REUSING_COUNTER_MODE_VECTORS(createRule(3,
-            "Avoid reusing counter mode initialization vectors", VULNERABILITY));
+            "Avoid reusing counter mode initialization vectors", VULNERABILITY)),
+    AVOID_USING_UNSECURE_RANDOM_NUMBER_GENERATORS(createRule(4,
+            "Secure random number generators should not output predictable values", VULNERABILITY));
 
     private final Rule rule;
 

--- a/compiler-plugin/src/main/resources/rules.json
+++ b/compiler-plugin/src/main/resources/rules.json
@@ -13,5 +13,10 @@
     "id": 3,
     "kind": "VULNERABILITY",
     "description": "Avoid reusing counter mode initialization vectors"
+  },
+  {
+    "id": 4,
+    "kind": "VULNERABILITY",
+    "description": "Secure random number generators should not output predictable values"
   }
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ stdlibTimeVersion=2.7.0
 stdlibIoVersion=1.8.0
 
 testngVersion=7.6.1
-balScanVersion=0.10.0
+balScanVersion=0.11.0


### PR DESCRIPTION
Implemented a new static code analysis rule that checks for the usage of unsecure random number generation in the context of cryptographic functions. This includes identifying calls to random:createIntInRange() for initialization vectors in AES-GCM and AES-ECB functions. Additionally, updated related files and tests to support this new rule.

## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8258

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
