### PR TITLE
Add support for RSASSA-PSS (PS256) algorithm

### DIFF
--- a/ballerina/sign_verify.bal
+++ b/ballerina/sign_verify.bal
@@ -136,6 +136,26 @@ public isolated function signRsaSha512(byte[] input, PrivateKey privateKey) retu
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
 
+# Returns the RSASSA-PSS with SHA-256 based signature value for the given data.
+# ```ballerina
+# string input = "Hello Ballerina";
+# byte[] data = input.toBytes();
+# crypto:KeyStore keyStore = {
+#     path: "/path/to/keyStore.p12",
+#     password: "keyStorePassword"
+# };
+# crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+# byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+# ```
+#
+# + input - The content to be signed
+# + privateKey - Private key used for signing
+# + return - The generated signature or else a `crypto:Error` if the private key is invalid
+public isolated function signRsaSsaPss256(byte[] input, PrivateKey privateKey) returns byte[]|Error = @java:Method {
+    name: "signRsaSsaPss256",
+    'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
+} external;
+
 # Returns the SHA384withECDSA based signature value for the given data.
 # ```ballerina
 # string input = "Hello Ballerina";
@@ -195,7 +215,7 @@ public isolated function signSha256withEcdsa(byte[] input, PrivateKey privateKey
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaMd5Signature(byte[] data, byte[] signature, PublicKey publicKey)
-                                               returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifyRsaMd5Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
@@ -219,7 +239,7 @@ public isolated function verifyRsaMd5Signature(byte[] data, byte[] signature, Pu
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyMlDsa65Signature(byte[] data, byte[] signature, PublicKey publicKey)
-                                               returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifyMlDsa65Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
@@ -267,7 +287,7 @@ public isolated function verifyRsaSha1Signature(byte[] data, byte[] signature, P
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaSha256Signature(byte[] data, byte[] signature, PublicKey publicKey)
-                                                  returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifyRsaSha256Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
@@ -291,7 +311,7 @@ public isolated function verifyRsaSha256Signature(byte[] data, byte[] signature,
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaSha384Signature(byte[] data, byte[] signature, PublicKey publicKey)
-                                                  returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifyRsaSha384Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
@@ -315,8 +335,32 @@ public isolated function verifyRsaSha384Signature(byte[] data, byte[] signature,
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaSha512Signature(byte[] data, byte[] signature, PublicKey publicKey)
-                                                  returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifyRsaSha512Signature",
+    'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
+} external;
+
+# Verifies the RSASSA-PSS with SHA-256 based signature.
+# ```ballerina
+# string input = "Hello Ballerina";
+# byte[] data = input.toBytes();
+# crypto:KeyStore keyStore = {
+#     path: "/path/to/keyStore.p12",
+#     password: "keyStorePassword"
+# };
+# crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+# byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+# crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keyStore, "keyAlias");
+# boolean validity = check crypto:verifyRsaSsaPss256Signature(data, signature, publicKey);
+# ```
+#
+# + data - The content to be verified
+# + signature - Signature value
+# + publicKey - Public key used for verification
+# + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
+public isolated function verifyRsaSsaPss256Signature(byte[] data, byte[] signature, PublicKey publicKey)
+                                                    returns boolean|Error = @java:Method {
+    name: "verifyRsaSsaPss256Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
 
@@ -339,7 +383,7 @@ public isolated function verifyRsaSha512Signature(byte[] data, byte[] signature,
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifySha384withEcdsaSignature(byte[] data, byte[] signature, PublicKey publicKey)
-                                                  returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifySha384withEcdsaSignature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
@@ -363,7 +407,7 @@ public isolated function verifySha384withEcdsaSignature(byte[] data, byte[] sign
 # + publicKey - Public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifySha256withEcdsaSignature(byte[] data, byte[] signature, PublicKey publicKey)
-                                                  returns boolean|Error = @java:Method {
+                                                returns boolean|Error = @java:Method {
     name: "verifySha256withEcdsaSignature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;

--- a/ballerina/sign_verify.bal
+++ b/ballerina/sign_verify.bal
@@ -359,7 +359,6 @@ public isolated function verifyRsaSha512Signature(byte[] data, byte[] signature,
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaSsaPss256Signature(byte[] data, byte[] signature, PublicKey publicKey)
                                                     returns boolean|Error = @java:Method {
-    name: "verifyRsaSsaPss256Signature",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
 

--- a/ballerina/sign_verify.bal
+++ b/ballerina/sign_verify.bal
@@ -152,7 +152,6 @@ public isolated function signRsaSha512(byte[] input, PrivateKey privateKey) retu
 # + privateKey - Private key used for signing
 # + return - The generated signature or else a `crypto:Error` if the private key is invalid
 public isolated function signRsaSsaPss256(byte[] input, PrivateKey privateKey) returns byte[]|Error = @java:Method {
-    name: "signRsaSsaPss256",
     'class: "io.ballerina.stdlib.crypto.nativeimpl.Sign"
 } external;
 

--- a/ballerina/tests/sign_verify_test.bal
+++ b/ballerina/tests/sign_verify_test.bal
@@ -107,6 +107,18 @@ isolated function testSignRsaSha512() returns Error? {
 }
 
 @test:Config {}
+isolated function testSignRsaSsaPss256() returns Error? {
+    byte[] payload = "Ballerina test".toBytes();
+    KeyStore keyStore = {
+        path: KEYSTORE_PATH,
+        password: "ballerina"
+    };
+    PrivateKey privateKey = check decodeRsaPrivateKeyFromKeyStore(keyStore, "ballerina", "ballerina");
+    byte[] pssSignature = check signRsaSsaPss256(payload, privateKey);
+    test:assertTrue(pssSignature.length() > 0);
+}
+
+@test:Config {}
 isolated function testSignMlDsa65() returns Error? {
     byte[] payload = "Ballerina test".toBytes();
     KeyStore keyStore = {
@@ -204,7 +216,7 @@ isolated function testSignMlDsa65() returns Error? {
 @test:Config {}
 isolated function testSignRsaMd5WithInvalidKey() {
     byte[] payload = "Ballerina test".toBytes();
-    PrivateKey privateKey = {algorithm:"RSA"};
+    PrivateKey privateKey = {algorithm: "RSA"};
     byte[]|Error result = signRsaMd5(payload, privateKey);
     if result is Error {
         test:assertTrue(result.message().includes("Uninitialized private key:"));
@@ -216,7 +228,7 @@ isolated function testSignRsaMd5WithInvalidKey() {
 @test:Config {}
 isolated function testSignRsaSha1WithInvalidKey() {
     byte[] payload = "Ballerina test".toBytes();
-    PrivateKey privateKey = {algorithm:"RSA"};
+    PrivateKey privateKey = {algorithm: "RSA"};
     byte[]|Error result = signRsaSha1(payload, privateKey);
     if result is Error {
         test:assertTrue(result.message().includes("Uninitialized private key:"));
@@ -228,7 +240,7 @@ isolated function testSignRsaSha1WithInvalidKey() {
 @test:Config {}
 isolated function testSignRsaSha256WithInvalidKey() {
     byte[] payload = "Ballerina test".toBytes();
-    PrivateKey privateKey = {algorithm:"RSA"};
+    PrivateKey privateKey = {algorithm: "RSA"};
     byte[]|Error result = signRsaSha256(payload, privateKey);
     if result is Error {
         test:assertTrue(result.message().includes("Uninitialized private key:"));
@@ -240,7 +252,7 @@ isolated function testSignRsaSha256WithInvalidKey() {
 @test:Config {}
 isolated function testSignRsaSha384WithInvalidKey() {
     byte[] payload = "Ballerina test".toBytes();
-    PrivateKey privateKey = {algorithm:"RSA"};
+    PrivateKey privateKey = {algorithm: "RSA"};
     byte[]|Error result = signRsaSha384(payload, privateKey);
     if result is Error {
         test:assertTrue(result.message().includes("Uninitialized private key:"));
@@ -252,8 +264,20 @@ isolated function testSignRsaSha384WithInvalidKey() {
 @test:Config {}
 isolated function testSignRsaSha512WithInvalidKey() {
     byte[] payload = "Ballerina test".toBytes();
-    PrivateKey privateKey = {algorithm:"RSA"};
+    PrivateKey privateKey = {algorithm: "RSA"};
     byte[]|Error result = signRsaSha512(payload, privateKey);
+    if result is Error {
+        test:assertTrue(result.message().includes("Uninitialized private key:"));
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@test:Config {}
+isolated function testSignRsaSsaPss256WithInvalidKey() {
+    byte[] payload = "Ballerina test".toBytes();
+    PrivateKey privateKey = {algorithm: "RSA"};
+    byte[]|Error result = signRsaSsaPss256(payload, privateKey);
     if result is Error {
         test:assertTrue(result.message().includes("Uninitialized private key:"));
     } else {
@@ -336,6 +360,19 @@ isolated function testVerifyRsaSha512() returns Error? {
     PublicKey publicKey = check decodeRsaPublicKeyFromTrustStore(keyStore, "ballerina");
     byte[] sha512Signature = check signRsaSha512(payload, privateKey);
     test:assertTrue(check verifyRsaSha512Signature(payload, sha512Signature, publicKey));
+}
+
+@test:Config {}
+isolated function testVerifyRsaSsaPss256() returns Error? {
+    byte[] payload = "Ballerina test".toBytes();
+    KeyStore keyStore = {
+        path: KEYSTORE_PATH,
+        password: "ballerina"
+    };
+    PrivateKey privateKey = check decodeRsaPrivateKeyFromKeyStore(keyStore, "ballerina", "ballerina");
+    PublicKey publicKey = check decodeRsaPublicKeyFromTrustStore(keyStore, "ballerina");
+    byte[] pssSignature = check signRsaSsaPss256(payload, privateKey);
+    test:assertTrue(check verifyRsaSsaPss256Signature(payload, pssSignature, publicKey));
 }
 
 @test:Config {}

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Introduce support for RSASSA-PSS (PS256) signature algorithm](https://github.com/ballerina-platform/ballerina-library/issues/8292)
 - [Introduce support for PBKDF2 password hashing and verification](https://github.com/ballerina-platform/ballerina-lang/issues/43926)
 - [Add static analysis rule - Encryption algorithms should be used with secure mode and padding scheme](https://github.com/ballerina-platform/ballerina-library/issues/7940)
 - [Add static analysis rule - Passwords should not be stored in plaintext or with a fast hashing algorithm](https://github.com/ballerina-platform/ballerina-library/issues/7950)

--- a/docs/proposals/rsassa-pss-signature-support.md
+++ b/docs/proposals/rsassa-pss-signature-support.md
@@ -1,0 +1,94 @@
+# Proposal: Introduce RSASSA-PSS (PS256) Signature Support to Ballerina Crypto Module
+
+_Authors_: @randilt  
+_Reviewers_:  
+_Created_: 2025/10/01  
+_Updated_: 2025/10/01  
+_Issue_: [#8292](https://github.com/ballerina-platform/ballerina-library/issues/8292)
+
+## Summary
+
+This proposal introduces support for the RSASSA-PSS signature scheme with SHA-256 (PS256) to the Ballerina Crypto Module. Currently, only classic RSA signatures (PKCS#1 v1.5) are available, but RSASSA-PSS provides enhanced security properties and is increasingly required by modern cryptographic standards and protocols.
+
+## Goals
+
+- Provide support for RSASSA-PSS signature generation with SHA-256
+- Provide support for RSASSA-PSS signature verification with SHA-256
+- Enable higher-level modules like JWT to utilize PS256 signatures
+
+## Motivation
+
+The Ballerina Crypto Module currently supports several RSA signature algorithms using PKCS#1 v1.5 padding (RSA-MD5, RSA-SHA1, RSA-SHA256, RSA-SHA384, RSA-SHA512). However, RSASSA-PSS, which is defined in RFC 8017 and provides enhanced security properties, is not yet supported.
+
+RSASSA-PSS offers several advantages over PKCS#1 v1.5:
+
+1. **Provable Security**: RSASSA-PSS has a security proof in the random oracle model
+2. **Probabilistic Signatures**: Uses random salt generation, making signatures non-deterministic
+3. **Modern Standard**: Required by many modern protocols and standards, including JWT RS256 alternative (PS256)
+4. **Recommended by Standards**: NIST and other standards bodies recommend RSASSA-PSS over PKCS#1 v1.5
+
+The lack of native support for RSASSA-PSS limits the cryptographic capabilities of Ballerina applications, particularly those implementing modern security protocols that require or prefer PS256 signatures.
+
+## Description
+
+This proposal adds RSASSA-PSS signature generation and verification with SHA-256 to the Ballerina Crypto Module, following the same architectural patterns as existing RSA signature functions.
+
+The key functionalities expected from this change are:
+
+- API to generate RSASSA-PSS signatures with `crypto:signRsaSsaPss256`
+- API to verify RSASSA-PSS signatures with `crypto:verifyRsaSsaPss256Signature`
+
+### API additions
+
+Two new APIs will be added following the existing RSA signature function patterns:
+
+```ballerina
+# Returns the RSASSA-PSS based signature value for the given data.
+#
+# + input - The content to be signed
+# + privateKey - Private key used for signing
+# + return - The generated signature or else a `crypto:Error` if the private key is invalid
+public isolated function signRsaSsaPss256(byte[] input, PrivateKey privateKey) returns byte[]|Error;
+```
+
+```ballerina
+# Verifies the RSASSA-PSS based signature.
+#
+# + data - The content to be verified
+# + signature - Signature value
+# + publicKey - Public key used for verification
+# + return - Validity of the signature or else a `crypto:Error` if the key is invalid
+public isolated function verifyRsaSsaPss256Signature(byte[] data, byte[] signature, PublicKey publicKey) returns boolean|Error;
+```
+
+### Implementation Details
+
+The implementation follows the existing architecture:
+
+1. **Java Native Implementation**: Uses Java's `Signature.getInstance("SHA256withRSAandMGF1")` with default PSS parameters
+2. **Algorithm String**: Uses `"SHA256withRSAandMGF1"` directly as string literal, consistent with other algorithms
+3. **Method Naming**: Follows the pattern `signRsaSsaPss256` and `verifyRsaSsaPss256Signature`
+4. **Documentation**: Matches the style and format of existing signature functions
+
+### PSS Parameters
+
+The implementation uses Java's default RSASSA-PSS parameters:
+
+- **Hash Algorithm**: SHA-256
+- **MGF**: MGF1 with SHA-256
+- **Salt Length**: Same as hash length (32 bytes for SHA-256)
+- **Trailer Field**: 1 (standard value)
+
+These parameters align with common RSASSA-PSS usage and provide strong security guarantees.
+
+## Testing
+
+The implementation includes comprehensive test coverage following the existing test patterns:
+
+1. **Basic Signing Test**: Verifies signature generation returns valid length (probabilistic nature prevents deterministic comparison)
+2. **Invalid Key Test**: Verifies proper error handling with invalid private keys
+3. **Sign-Verify Test**: Tests complete workflow of signing with private key and verifying with corresponding public key
+
+## Backward Compatibility
+
+This addition is fully backward compatible as it only adds new functions without modifying existing APIs or behavior.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -73,18 +73,20 @@ The conforming implementation of the specification is released and included in t
         - 6.1.3. [RSA-SHA256](#613-rsa-sha256)
         - 6.1.4. [RSA-SHA384](#614-rsa-sha384)
         - 6.1.5. [RSA-SHA512](#615-rsa-sha512)
-        - 6.1.6. [SHA384withECDSA](#616-sha384withecdsa)
-        - 6.1.7. [SHA256withECDSA](#617-sha256withecdsa)
-        - 6.1.8. [ML-DSA-65](#618-ml-dsa-65)
+        - 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
+        - 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
+        - 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
+        - 6.1.9. [ML-DSA-65](#619-mldsa65)
     - 6.2. [Verify signature](#62-verify-signature)
         - 6.2.1. [RSA-MD5](#621-rsa-md5)
         - 6.2.2. [RSA-SHA1](#622-rsa-sha1)
         - 6.2.3. [RSA-SHA256](#623-rsa-sha256)
         - 6.2.4. [RSA-SHA384](#624-rsa-sha384)
         - 6.2.5. [RSA-SHA512](#625-rsa-sha512)
-        - 6.2.6. [SHA384withECDSA](#626-sha384withecdsa)
-        - 6.2.7. [SHA256withECDSA](#627-sha256withecdsa)
-        - 6.2.8. [ML-DSA-65](#628-ml-dsa-65)
+        - 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
+        - 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
+        - 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
+        - 6.2.9. [ML-DSA-65](#629-mldsa65)
 7. [Key Derivation Function (KDF)](#7-key-derivation-function-kdf)
     - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
 8. [Key Exchange Mechanism (KEM)](#8-key-exchange-mechanism-kem)
@@ -741,7 +743,22 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha512(data, privateKey);
 ```
 
-#### 6.1.6. SHA384withECDSA
+#### 6.1.6. RSASSA-PSS-SHA256
+
+This API can be used to create the RSASSA-PSS based signature value for the given data.
+
+```ballerina
+string input = "Hello Ballerina";
+byte[] data = input.toBytes();
+crypto:KeyStore keyStore = {
+    path: "/path/to/keyStore.p12",
+    password: "keyStorePassword"
+};
+crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+```
+
+#### 6.1.7. SHA384withECDSA
 
 This API can be used to create the SHA384withECDSA based signature value for the given data.
 
@@ -756,7 +773,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha384withEcdsa(data, privateKey);
 ```
 
-#### 6.1.7. SHA256withECDSA
+#### 6.1.8. SHA256withECDSA
 
 This API can be used to create the SHA256withECDSA based signature value for the given data.
 
@@ -771,7 +788,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha256withEcdsa(data, privateKey);
 ```
 
-#### 6.1.8. ML-DSA-65
+#### 6.1.9. ML-DSA-65
 
 This API can be used to create the ML-DSA-65 based signature value for the given data.
 
@@ -873,7 +890,24 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha512Signature(data, signature, publicKey);
 ```
 
-#### 6.2.6. SHA384withECDSA
+#### 6.2.6. RSASSA-PSS-SHA256
+
+This API can be used to verify the RSASSA-PSS based signature.
+
+```ballerina
+string input = "Hello Ballerina";
+byte[] data = input.toBytes();
+crypto:KeyStore keyStore = {
+    path: "/path/to/keyStore.p12",
+    password: "keyStorePassword"
+};
+crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keyStore, "keyAlias");
+boolean validity = check crypto:verifyRsaSsaPss256Signature(data, signature, publicKey);
+```
+
+#### 6.2.7. SHA384withECDSA
 
 This API can be used to verify the SHA384withECDSA based signature.
 
@@ -890,7 +924,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha384withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.7. SHA256withECDSA
+#### 6.2.8. SHA256withECDSA
 
 This API can be used to verify the SHA256withECDSA based signature.
 
@@ -907,7 +941,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha256withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.8. ML-DSA-65
+#### 6.2.9. ML-DSA-65
 
 This API can be used to verify the ML-DSA-65 based signature.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -5,6 +5,7 @@ _Reviewers_: @shafreenAnfar
 _Created_: 2022/08/23  
 _Updated_: 2025/01/20  
 _Edition_: Swan Lake
+_Edition_: Swan Lake
 
 ## Introduction
 
@@ -18,6 +19,7 @@ The conforming implementation of the specification is released and included in t
 
 ## Contents
 
+
 1. [Overview](#1-overview)
 2. [Hash](#2-hash)
     - 2.1. [MD5](#21-md5)
@@ -27,7 +29,52 @@ The conforming implementation of the specification is released and included in t
     - 2.5. [SHA512](#25-sha512)
     - 2.6. [CRC32B](#26-crc32b)
     - 2.7. [KECCAK256](#27-keccak256)
+    - 2.1. [MD5](#21-md5)
+    - 2.2. [SHA1](#22-sha1)
+    - 2.3. [SHA256](#23-sha256)
+    - 2.4. [SHA384](#24-sha384)
+    - 2.5. [SHA512](#25-sha512)
+    - 2.6. [CRC32B](#26-crc32b)
+    - 2.7. [KECCAK256](#27-keccak256)
 3. [HMAC](#3-hmac)
+    - 3.1. [MD5](#31-md5)
+    - 3.2. [SHA1](#32-sha1)
+    - 3.3. [SHA256](#33-sha256)
+    - 3.4. [SHA384](#34-sha384)
+    - 3.5. [SHA512](#35-sha512)
+4. [Decode private/public key](#4-decode-privatepublic-key)
+    - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
+    - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
+    - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
+    - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
+    - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
+    - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
+    - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
+    - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
+    - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
+    - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
+    - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
+    - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
+    - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
+    - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
+    - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
+    - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
+    - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
+    - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
+    - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
+5. [Encrypt-Decrypt](#5-encrypt-decrypt)
+    - 5.1. [Encryption](#51-encryption)
+        - 5.1.1. [RSA](#511-rsa)
+        - 5.1.2. [AES-CBC](#512-aes-cbc)
+        - 5.1.3. [AES-ECB](#513-aes-ecb)
+        - 5.1.4. [AES-GCM](#514-aes-gcm)
+        - 5.1.5. [PGP](#515-pgp)
+    - 5.2. [Decryption](#52-decryption)
+        - 5.2.1. [RSA-ECB](#521-rsa-ecb)
+        - 5.2.2. [AES-CBC](#522-aes-cbc)
+        - 5.2.3. [AES-ECB](#523-aes-ecb)
+        - 5.2.4. [AES-GCM](#524-aes-gcm)
+        - 5.2.5. [PGP](#525-pgp)
     - 3.1. [MD5](#31-md5)
     - 3.2. [SHA1](#32-sha1)
     - 3.3. [SHA256](#33-sha256)
@@ -89,6 +136,7 @@ The conforming implementation of the specification is released and included in t
        * 6.2.9. [ML-DSA-65](#629-mldsa65)
 7. [Key Derivation Function (KDF)](#7-key-derivation-function-kdf)
     - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
+    - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
 8. [Key Exchange Mechanism (KEM)](#8-key-exchange-mechanism-kem)
     - 8.1 [Encapsulation](#81-encapsulation)
         - 8.1.1 [RSA-KEM](#811-rsa-kem)
@@ -98,7 +146,21 @@ The conforming implementation of the specification is released and included in t
         - 8.2.1 [RSA-KEM](#821-rsa-kem)
         - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
         - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
+    - 8.1 [Encapsulation](#81-encapsulation)
+        - 8.1.1 [RSA-KEM](#811-rsa-kem)
+        - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
+        - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
+    - 8.2 [Decapsulation](#81-encapsulation)
+        - 8.2.1 [RSA-KEM](#821-rsa-kem)
+        - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
+        - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
 9. [Hybrid Public Key Encryption (HPKE)](#9-hybrid-public-key-encryption-hpke)
+    - 9.1 [Encrypt](#91-encrypt)
+        - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
+        - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
+    - 9.2 [Decrypt](#92-decrypt)
+        - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
+        - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
     - 9.1 [Encrypt](#91-encrypt)
         - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
         - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
@@ -115,16 +177,28 @@ The conforming implementation of the specification is released and included in t
     - 11.3 [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)
 
 ## 1. Overview
+    - 10.1 [BCrypt](#101-bcrypt)
+    - 10.2 [Argon2](#102-argon2)
+    - 10.3 [PBKDF2](#103-pbkdf2)
+11. [Static Code Rules](#11-static-code-rules)
+    - 11.1 [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes)
+    - 11.2 [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)
+    - 11.3 [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)
+
+## 1. Overview
 
 The Ballerina `crypto` library facilitates APIs to do operations like hashing, HMAC generation, checksum generation, encryption, decryption, signing data digitally, verifying digitally signed data, etc., with different cryptographic algorithms.
 
+## 2. Hash
 ## 2. Hash
 
 The `crypto` library supports generating hashes with 5 different hash algorithms MD5, SHA1, SHA256, SHA384, and SHA512. Also, it supports generating the CRC32B checksum.
 
 ### 2.1. MD5
+### 2.1. MD5
 
 This API can be used to create the MD5 hash of the given data.
+
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -133,8 +207,10 @@ byte[] hash = crypto:hashMd5(data);
 ```
 
 ### 2.2. SHA1
+### 2.2. SHA1
 
 This API can be used to create the SHA-1 hash of the given data.
+
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -143,8 +219,10 @@ byte[] hash = crypto:hashSha1(data);
 ```
 
 ### 2.3. SHA256
+### 2.3. SHA256
 
 This API can be used to create the SHA-256 hash of the given data.
+
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -153,8 +231,10 @@ byte[] hash = crypto:hashSha256(data);
 ```
 
 ### 2.4. SHA384
+### 2.4. SHA384
 
 This API can be used to create the SHA-384 hash of the given data.
+
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -163,8 +243,10 @@ byte[] hash = crypto:hashSha384(data);
 ```
 
 ### 2.5. SHA512
+### 2.5. SHA512
 
 This API can be used to create the SHA-512 hash of the given data.
+
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -173,8 +255,10 @@ byte[] hash = crypto:hashSha512(data);
 ```
 
 ### 2.6. CRC32B
+### 2.6. CRC32B
 
 This API can be used to create the Hex-encoded CRC32B value of the given data.
+
 
 ```ballerina
 string stringData = "Hello Ballerina";
@@ -183,8 +267,10 @@ string checksum = crypto:crc32b(data);
 ```
 
 ### 2.7. KECCAK256
+### 2.7. KECCAK256
 
 This API can be used to create the Hex-encoded KECCAK-256 value of the given data.
+
 
 ```ballerina
 string stringData = "Hello Ballerina";
@@ -193,9 +279,11 @@ string checksum = crypto:hashKeccak256(data);
 ```
 
 ## 3. HMAC
+## 3. HMAC
 
 The `crypto` library supports generating HMAC with 5 different hash algorithms: MD5, SHA1, SHA256, SHA384, and SHA512.
 
+### 3.1. MD5
 ### 3.1. MD5
 
 This API can be used to create HMAC using the MD5 hash function of the given data.
@@ -209,6 +297,7 @@ byte[] hmac = check crypto:hmacMd5(data, key);
 ```
 
 ### 3.2. SHA1
+### 3.2. SHA1
 
 This API can be used to create HMAC using the SHA-1 hash function of the given data.
 
@@ -220,6 +309,7 @@ byte[] key = secret.toBytes();
 byte[] hmac = crypto:hmacSha1(data, key);
 ```
 
+### 3.3. SHA256
 ### 3.3. SHA256
 
 This API can be used to create HMAC using the SHA-256 hash function of the given data.
@@ -233,6 +323,7 @@ byte[] hmac = check crypto:hmacSha256(data, key);
 ```
 
 ### 3.4. SHA384
+### 3.4. SHA384
 
 This API can be used to create HMAC using the SHA-384 hash function of the given data.
 
@@ -244,6 +335,7 @@ byte[] key = secret.toBytes();
 byte[] hmac = check crypto:hmacSha384(data, key);
 ```
 
+### 3.5. SHA512
 ### 3.5. SHA512
 
 This API can be used to create HMAC using the SHA-512 hash function of the given data.
@@ -257,9 +349,11 @@ byte[] hmac = check crypto:hmacSha512(data, key);
 ```
 
 ## 4. Decode private/public key
+## 4. Decode private/public key
 
 The `crypto` library supports decoding the RSA private key from a `.p12` file and a key file in the `PEM` format. Also, it supports decoding a public key from a `.p12` file and a certificate file in the `X509` format. Additionally, this supports building an RSA public key with the modulus and exponent parameters.
 
+### 4.1. Decode RSA Private key from PKCS12 file
 ### 4.1. Decode RSA Private key from PKCS12 file
 
 This API can be used to decode the RSA private key from the given PKCS#12 file.
@@ -273,6 +367,7 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 ```
 
 ### 4.2. Decode RSA Private key using Private key and Password
+### 4.2. Decode RSA Private key using Private key and Password
 
 This API can be used to decode the RSA private key from the given private key and private key password.
 
@@ -282,6 +377,7 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyFile(keyFi
 ```
 
 ## 4.3. Decode RSA Private key using Private key content and Password
+## 4.3. Decode RSA Private key using Private key content and Password
 
 This API can be used to decode the RSA public key from the given public certificate content as a byte array.
 
@@ -290,6 +386,7 @@ byte[] keyContent = [45,45,45,45,45,66,69,71,73,78,...];
 crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromContent(keyContent);
 ```
 
+### 4.4. Decode RSA Public key from PKCS12 file
 ### 4.4. Decode RSA Public key from PKCS12 file
 
 This API can be used to decode the RSA public key from the given PKCS#12 archive file.
@@ -303,6 +400,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(trust
 ```
 
 ### 4.5. Decode RSA Public key from the certificate file
+### 4.5. Decode RSA Public key from the certificate file
 
 This API can be used to decode the RSA public key from the given public certificate file.
 
@@ -312,6 +410,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromCertFile(certFil
 ```
 
 ### 4.6. Decode RSA Public key from the certificate content
+### 4.6. Decode RSA Public key from the certificate content
 
 This API can be used to decode the RSA public key from the given public certificate content as a byte array.
 
@@ -320,6 +419,7 @@ byte[] certFileContent = [45,45,45,45,45,66,69,71,73,78,...];
 crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromContent(certFileContent);
 ```
 
+### 4.7. Decode EC Private key from PKCS12 file
 ### 4.7. Decode EC Private key from PKCS12 file
 
 This API can be used to decode the EC private key from the given PKCS#12 file.
@@ -333,6 +433,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 ```
 
 ### 4.8. Decode EC Private key using Private key and Password
+### 4.8. Decode EC Private key using Private key and Password
 
 This API can be used to decode the EC private key from the given private key and private key password.
 
@@ -341,6 +442,7 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
+### 4.9. Decode EC Public key from PKCS12 file
 ### 4.9. Decode EC Public key from PKCS12 file
 
 This API can be used to decode the RSA public key from the given PKCS#12 archive file.
@@ -354,6 +456,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(trustS
 ```
 
 ### 4.10. Decode EC Public key from the certificate file
+### 4.10. Decode EC Public key from the certificate file
 
 This API can be used to decode the EC public key from the given public certificate file.
 
@@ -362,6 +465,7 @@ string certFile = "/path/to/public.cert";
 crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromCertFile(certFile);
 ```
 
+### 4.11. Build RSA Public key from modulus and exponent parameters
 ### 4.11. Build RSA Public key from modulus and exponent parameters
 
 This API can be used to build the RSA public key from the given modulus and exponent parameters.
@@ -376,6 +480,7 @@ crypto:PublicKey publicKey = check crypto:buildRsaPublicKey(modulus, exponent);
 ```
 
 ### 4.12. Decode ML-DSA-65 Private key from PKCS12 file
+### 4.12. Decode ML-DSA-65 Private key from PKCS12 file
 
 This API can be used to decode the ML-DSA-65 private key from the given PKCS#12 file.
 
@@ -388,6 +493,7 @@ crypto:PrivateKey privateKey = check crypto:decodeMlDsa65PrivateKeyFromKeyStore(
 ```
 
 ### 4.13. Decode ML-DSA-65 Private key using Private key and Password
+### 4.13. Decode ML-DSA-65 Private key using Private key and Password
 
 This API can be used to decode the ML-DSA-65 private key from the given private key and private key password.
 
@@ -396,6 +502,7 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeMlDsa65PrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
+### 4.14. Decode ML-DSA-65 Public key from PKCS12 file
 ### 4.14. Decode ML-DSA-65 Public key from PKCS12 file
 
 This API can be used to decode the ML-DSA-65 public key from the given PKCS#12 archive file.
@@ -409,6 +516,7 @@ crypto:PublicKey publicKey = check crypto:decodeMlDsa65PublicKeyFromTrustStore(t
 ```
 
 ### 4.15. Decode ML-DSA-65 Public key from the certificate file
+### 4.15. Decode ML-DSA-65 Public key from the certificate file
 
 This API can be used to decode the ML-DSA-65 public key from the given public certificate file.
 
@@ -417,6 +525,7 @@ string certFile = "/path/to/public.cert";
 crypto:PublicKey publicKey = check crypto:decodeMlDsa65PublicKeyFromCertFile(certFile);
 ```
 
+### 4.16. Decode ML-KEM-768 Private key from PKCS12 file
 ### 4.16. Decode ML-KEM-768 Private key from PKCS12 file
 
 This API can be used to decode the ML-KEM-768 private key from the given PKCS#12 file.
@@ -430,6 +539,7 @@ crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyStore
 ```
 
 ### 4.17. Decode ML-KEM-768 Private key using Private key and Password
+### 4.17. Decode ML-KEM-768 Private key using Private key and Password
 
 This API can be used to decode the ML-KEM-768 private key from the given private key and private key password.
 
@@ -438,6 +548,7 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
+### 4.18. Decode ML-KEM-768 Public key from PKCS12 file
 ### 4.18. Decode ML-KEM-768 Public key from PKCS12 file
 
 This API can be used to decode the ML-KEM-768 public key from the given PKCS#12 archive file.
@@ -451,6 +562,7 @@ crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromTrustStore(
 ```
 
 ### 4.19. Decode ML-KEM-768 Public key from the certificate file
+### 4.19. Decode ML-KEM-768 Public key from the certificate file
 
 This API can be used to decode the ML-KEM-768 public key from the given public certificate file.
 
@@ -460,11 +572,14 @@ crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromCertFile(ce
 ```
 
 ## 5. Encrypt-Decrypt
+## 5. Encrypt-Decrypt
 
 The `crypto` library supports both symmetric key encryption/decryption and asymmetric key encryption/decryption. The RSA algorithm can be used for asymmetric-key encryption/decryption with the use of private and public keys. The AES algorithm can be used for symmetric-key encryption/decryption with the use of a shared key.
 
 ### 5.1. Encryption
+### 5.1. Encryption
 
+#### 5.1.1. RSA
 #### 5.1.1. RSA
 
 This API can be used to create the RSA-encrypted value of the given data.
@@ -480,6 +595,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
 ```
 
+#### 5.1.2. AES-CBC
 #### 5.1.2. AES-CBC
 
 This API can be used to create the AES-CBC-encrypted value for the given data.
@@ -499,6 +615,7 @@ byte[] cipherText = check crypto:encryptAesCbc(data, key, initialVector);
 ```
 
 #### 5.1.3. AES-ECB
+#### 5.1.3. AES-ECB
 
 This API can be used to create the AES-ECB-encrypted value for the given data.
 
@@ -512,6 +629,7 @@ foreach int i in 0...15 {
 byte[] cipherText = check crypto:encryptAesEcb(data, key);
 ```
 
+#### 5.1.4. AES-GCM
 #### 5.1.4. AES-GCM
 
 This API can be used to create the AES-GCM-encrypted value for the given data.
@@ -530,6 +648,7 @@ foreach int i in 0...15 {
 byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
 ```
 
+#### 5.1.5. PGP
 #### 5.1.5. PGP
 
 This API can be used to create the PGP-encrypted value for the given data.
@@ -568,7 +687,9 @@ stream<byte[], crypto:Error?>|crypto:Error encryptedStream = crypto:encryptStrea
 ```
 
 ### 5.2. Decryption
+### 5.2. Decryption
 
+#### 5.2.1. RSA-ECB
 #### 5.2.1. RSA-ECB
 
 This API can be used to create the RSA-decrypted value for the given RSA-encrypted data.
@@ -586,6 +707,7 @@ byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
 byte[] plainText = check crypto:decryptRsaEcb(cipherText, privateKey);
 ```
 
+#### 5.2.2. AES-CBC
 #### 5.2.2. AES-CBC
 
 This API can be used to create the AES-CBC-decrypted value for the given AES-CBC-encrypted data.
@@ -606,6 +728,7 @@ byte[] plainText = check crypto:decryptAesCbc(cipherText, key, initialVector);
 ```
 
 #### 5.2.3. AES-ECB
+#### 5.2.3. AES-ECB
 
 This API can be used to create the AES-ECB-decrypted value for the given AES-ECB-encrypted data.
 
@@ -620,6 +743,7 @@ byte[] cipherText = check crypto:encryptAesEcb(data, key);
 byte[] plainText = check crypto:decryptAesEcb(cipherText, key);
 ```
 
+#### 5.2.4. AES-GCM
 #### 5.2.4. AES-GCM
 
 This API can be used to create the AES-GCM-decrypted value for the given AES-GCM-encrypted data.
@@ -639,6 +763,7 @@ byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
 byte[] plainText = check crypto:decryptAesGcm(cipherText, key, initialVector);
 ```
 
+#### 5.2.5. PGP
 #### 5.2.5. PGP
 
 This API can be used to create the PGP-decrypted value for the given PGP-encrypted data.
@@ -663,11 +788,14 @@ stream<byte[], crypto:Error?>|crypto:Error decryptedStream = crypto:decryptStrea
 ```
 
 ## 6. Sign and Verify
+## 6. Sign and Verify
 
 The `crypto` library supports signing data using the RSA private key and verification of the signature using the RSA public key. This supports MD5, SHA1, SHA256, SHA384, and SHA512 digesting algorithms, and ML-DSA-65 post-quantum signature algorithm as well.
 
 ### 6.1. Sign messages
+### 6.1. Sign messages
 
+#### 6.1.1. RSA-MD5
 #### 6.1.1. RSA-MD5
 
 This API can be used to create the RSA-MD5 based signature value for the given data.
@@ -684,6 +812,7 @@ byte[] signature = check crypto:signRsaMd5(data, privateKey);
 ```
 
 #### 6.1.2. RSA-SHA1
+#### 6.1.2. RSA-SHA1
 
 This API can be used to create the RSA-SHA1 based signature value for the given data.
 
@@ -698,6 +827,7 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha1(data, privateKey);
 ```
 
+#### 6.1.3. RSA-SHA256
 #### 6.1.3. RSA-SHA256
 
 This API can be used to create the RSA-SHA256 based signature value for the given data.
@@ -714,6 +844,7 @@ byte[] signature = check crypto:signRsaSha256(data, privateKey);
 ```
 
 #### 6.1.4. RSA-SHA384
+#### 6.1.4. RSA-SHA384
 
 This API can be used to create the RSA-SHA384 based signature value for the given data.
 
@@ -728,6 +859,7 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha384(data, privateKey);
 ```
 
+#### 6.1.5. RSA-SHA512
 #### 6.1.5. RSA-SHA512
 
 This API can be used to create the RSA-SHA512 based signature value for the given data.
@@ -804,7 +936,9 @@ byte[] signature = check crypto:signMlDsa65(data, privateKey);
 ```
 
 ### 6.2. Verify signature
+### 6.2. Verify signature
 
+#### 6.2.1. RSA-MD5
 #### 6.2.1. RSA-MD5
 
 This API can be used to verify the RSA-MD5 based signature.
@@ -823,6 +957,7 @@ boolean validity = check crypto:verifyRsaMd5Signature(data, signature, publicKey
 ```
 
 #### 6.2.2. RSA-SHA1
+#### 6.2.2. RSA-SHA1
 
 This API can be used to verify the RSA-SHA1 based signature.
 
@@ -839,6 +974,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha1Signature(data, signature, publicKey);
 ```
 
+#### 6.2.3. RSA-SHA256
 #### 6.2.3. RSA-SHA256
 
 This API can be used to verify the RSA-SHA256 based signature.
@@ -857,6 +993,7 @@ boolean validity = check crypto:verifyRsaSha256Signature(data, signature, public
 ```
 
 #### 6.2.4. RSA-SHA384
+#### 6.2.4. RSA-SHA384
 
 This API can be used to verify the RSA-SHA384 based signature.
 
@@ -873,6 +1010,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha384Signature(data, signature, publicKey);
 ```
 
+#### 6.2.5. RSA-SHA512
 #### 6.2.5. RSA-SHA512
 
 This API can be used to verify the RSA-SHA512 based signature.
@@ -959,9 +1097,11 @@ boolean validity = check crypto:verifyMlDsa65Signature(data, signature, publicKe
 ```
 
 ## 7. Key Derivation Function (KDF)
+## 7. Key Derivation Function (KDF)
 
 The `crypto` module supports HMAC-based Key Derivation Function (HKDF). HKDF is a key derivation function that uses a Hash-based Message Authentication Code (HMAC) to derive keys.
 
+### 7.1. HKDF-SHA256
 ### 7.1. HKDF-SHA256
 
 This API can be used to create HKDF using the SHA256 hash function of the given data.
@@ -973,13 +1113,18 @@ byte[] hash = crypto:hkdfSha256(key, 32);
 ```
 
 ## 8. Key Exchange Mechanism (KEM)
+## 8. Key Exchange Mechanism (KEM)
 
 The `crypto` module supports Key Exchange Mechanisms (KEM). It includes RSA-KEM and post-quantum ML-KEM-768 for both encapsulation and decapsulation.
 
 ### 8.1. Encapsulation
 
 #### 8.1.1. RSA-KEM
+### 8.1. Encapsulation
 
+#### 8.1.1. RSA-KEM
+
+This API can be used to create shared secret and its encapsulation using RSA-KEM function.
 This API can be used to create shared secret and its encapsulation using RSA-KEM function.
 
 ```ballerina
@@ -993,6 +1138,9 @@ crypto:EncapsulationResult encapsulationResult = check crypto:encapsulateRsaKem(
 
 #### 8.1.2. ML-KEM-768
 
+#### 8.1.2. ML-KEM-768
+
+This API can be used to create shared secret and its encapsulation using ML-KEM-768 function.
 This API can be used to create shared secret and its encapsulation using ML-KEM-768 function.
 
 ```ballerina
@@ -1006,6 +1154,9 @@ crypto:EncapsulationResult encapsulationResult = check crypto:encapsulateMlKem76
 
 #### 8.1.3. RSA-KEM-ML-KEM-768
 
+#### 8.1.3. RSA-KEM-ML-KEM-768
+
+This API can be used to create shared secret and its encapsulation using RSA-KEM-ML-KEM-768 function.
 This API can be used to create shared secret and its encapsulation using RSA-KEM-ML-KEM-768 function.
 
 ```ballerina
@@ -1029,7 +1180,11 @@ byte[] sharedSecret = check crypto:decapsulateRsaKemMlKem768(encapsulatedSecret,
 ### 8.2. Decapsulation
 
 #### 8.2.1. RSA-KEM
+### 8.2. Decapsulation
 
+#### 8.2.1. RSA-KEM
+
+This API can be used to decapsulate shared secret using RSA-KEM function of the given data.
 This API can be used to decapsulate shared secret using RSA-KEM function of the given data.
 
 ```ballerina
@@ -1046,6 +1201,9 @@ byte[] sharedSecret = check crypto:decapsulateRsaKem(encapsulatedSecret, private
 
 #### 8.2.2. ML-KEM-768
 
+#### 8.2.2. ML-KEM-768
+
+This API can be used to decapsulate shared secret using ML-KEM-768 function of the given data.
 This API can be used to decapsulate shared secret using ML-KEM-768 function of the given data.
 
 ```ballerina
@@ -1062,6 +1220,9 @@ byte[] sharedSecret = check crypto:decapsulateMlKem768(encapsulatedSecret, priva
 
 #### 8.2.3. RSA-KEM-ML-KEM-768
 
+#### 8.2.3. RSA-KEM-ML-KEM-768
+
+This API can be used to decapsulate shared secret using RSA-KEM-ML-KEM-768 function of the given data.
 This API can be used to decapsulate shared secret using RSA-KEM-ML-KEM-768 function of the given data.
 
 ```ballerina
@@ -1083,9 +1244,13 @@ byte[] sharedSecret = check crypto:decapsulateRsaKemMlKem768(encapsulatedSecret,
 ```
 
 ## 9. Hybrid Public Key Encryption (HPKE)
+## 9. Hybrid Public Key Encryption (HPKE)
 
 The `crypto` module supports Hybrid Public Key Encryption (HPKE). It supports post-quantum ML-KEM-768-HPKE and RSA-KEM-ML-KEM-768-HPKE for encryption and decryption.
 
+### 9.1. Encrypt
+
+#### 9.1.1. ML-KEM-768-HPKE
 ### 9.1. Encrypt
 
 #### 9.1.1. ML-KEM-768-HPKE
@@ -1102,6 +1267,8 @@ crypto:KeyStore keyStore = {
 crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromTrustStore(keyStore, "keyAlias");
 crypto:HybridEncryptionResult encryptionResult = check crypto:encryptMlKem768Hpke(data, publicKey);
 ```
+
+#### 9.1.2. RSA-KEM-ML-KEM-768-HPKE
 
 #### 9.1.2. RSA-KEM-ML-KEM-768-HPKE
 
@@ -1126,6 +1293,9 @@ crypto:HybridEncryptionResult encryptionResult = check crypto:encryptRsaKemMlKem
 ### 9.2. Decrypt
 
 #### 9.2.1. ML-KEM-768-HPKE
+### 9.2. Decrypt
+
+#### 9.2.1. ML-KEM-768-HPKE
 
 This API can be used to create the ML-KEM-768-hybrid-decrypted value of the given data.
 
@@ -1143,6 +1313,8 @@ byte[] encapsulatedKey = encryptionResult.encapsulatedSecret;
 crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyStore(keyStore, "keyAlias", "keyStorePassword");
 byte[] decryptedData = check crypto:decryptMlKem768Hpke(cipherText, encapsulatedKey, privateKey);
 ```
+
+#### 9.2.2. RSA-KEM-ML-KEM-768-HPKE
 
 #### 9.2.2. RSA-KEM-ML-KEM-768-HPKE
 
@@ -1170,9 +1342,11 @@ byte[] decryptedData = check crypto:decryptRsaKemMlKem768Hpke(cipherText, encaps
 ```
 
 ## 10. Password Hashing
+## 10. Password Hashing
 
 The `crypto` module provides password hashing using BCrypt and Argon2id algorithms for secure password storage.
 
+### 10.1 BCrypt
 ### 10.1 BCrypt
 
 Implements the BCrypt password hashing algorithm based on the Blowfish cipher.
@@ -1183,6 +1357,7 @@ public isolated function hashBcrypt(string password, int workFactor = 12) return
 
 Parameters:
 
+
 - `password`: The plain text password to hash
 - `workFactor`: Computational complexity factor (4-31, default: 12)
 
@@ -1191,6 +1366,7 @@ public isolated function verifyBcrypt(string password, string hashedPassword) re
 ```
 
 Example:
+
 
 ```ballerina
 string password = "your-password";
@@ -1202,6 +1378,7 @@ boolean isValid = check crypto:verifyBcrypt(password, hashedPassword1);
 ```
 
 ### 10.2 Argon2
+### 10.2 Argon2
 
 Implements the Argon2id variant of the Argon2 password hashing algorithm, optimized for both high memory usage and GPU resistance.
 
@@ -1211,6 +1388,7 @@ public isolated function hashArgon2(string password, int iterations = 3,
 ```
 
 Parameters:
+
 
 - `password`: The plain text password to hash
 - `iterations`: Number of iterations (default: 3)
@@ -1225,6 +1403,7 @@ public isolated function verifyArgon2(string password, string hashedPassword) re
 
 Example:
 
+
 ```ballerina
 string password = "your-password";
 // Hash with default parameters
@@ -1234,6 +1413,7 @@ string hashedPassword2 = check crypto:hashArgon2(password, iterations = 4, memor
 boolean isValid = check crypto:verifyArgon2(password, hashedPassword1);
 ```
 
+### 10.3 PBKDF2
 ### 10.3 PBKDF2
 
 Implements the PBKDF2 (Password-Based Key Derivation Function 2) algorithm for password hashing.
@@ -1281,6 +1461,352 @@ string hashedPassword = "$pbkdf2-sha256$i=10000$salt$hash";
 // Verify the hashed password
 boolean isValid = check crypto:verifyPbkdf2(password, hashedPassword);
 ```
+
+## 11. Static Code Rules
+
+The following static code rules are applied to the Crypto module.
+
+| Id                 | Kind          | Description                                                                                                       |
+|--------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
+| ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes) |
+| ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)                                   |
+| ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)       |
+
+### 11.1 Avoid using insecure cipher modes or padding schemes
+
+Using weak or outdated encryption modes and padding schemes can compromise the security of encrypted data, even when strong algorithms are used.
+
+## 11.1.1. Why this is an issue?
+
+Encryption algorithms are essential for protecting sensitive information and ensuring secure communications. When implementing encryption, it's critical to select not only strong algorithms but also secure modes of operation and padding schemes. Using weak or outdated encryption modes can compromise the security of otherwise strong algorithms.
+
+The security risks of using weak encryption modes include:
+
+- Data confidentiality breaches where encrypted content becomes readable
+- Modification of encrypted data without detection
+- Pattern recognition in encrypted data that reveals information about the plaintext
+- Replay attacks where valid encrypted data is reused maliciously
+- Known-plaintext attacks that can reveal encryption keys
+
+## 11.1.2. What is the potential impact?
+
+Common vulnerable patterns include:
+
+- Using ECB (Electronic Codebook) mode which doesn't hide data patterns
+- Implementing CBC (Cipher Block Chaining) without integrity checks
+- Using RSA encryption without proper padding schemes
+- Relying on outdated padding methods like PKCS1v1.5
+- Using stream ciphers with insufficient initialization vectors
+
+## 11.1.3. How can I fix this?
+
+Choose secure encryption modes and padding schemes that provide both confidentiality and integrity protection.
+
+### 11.1.3.1 AES Encryption Example
+
+**Non-compliant code :**
+
+```ballerina
+byte[] cipherText = check crypto:encryptAesEcb(data, key);
+```
+
+For AES, the weakest mode is ECB (Electronic Codebook). Repeated blocks of data are encrypted to the same value, making them easy to identify and reducing the difficulty of recovering the original cleartext.
+
+```ballerina
+byte[] cipherText = check crypto:encryptAesCbc(data, key, initialVector);
+```
+
+Unauthenticated modes such as CBC (Cipher Block Chaining) may be used but are prone to attacks that manipulate the ciphertext (like padding oracle attacks). They must be used with caution and additional integrity checks.
+
+**Compliant code:**
+
+```ballerina
+byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
+```
+
+AES-GCM (Galois/Counter Mode) provides authenticated encryption, ensuring both confidentiality and integrity of the encrypted data.
+
+### 11.1.3.2 RSA Encryption Example
+
+**Non-compliant code :**
+
+```ballerina
+// Default padding is PKCS1
+byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
+
+cipherText = check crypto:encryptRsaEcb(data, publicKey, crypto:PKCS1);
+```
+
+For RSA, avoid using PKCS1v1.5 padding as it is vulnerable to various attacks. Instead, use OAEP (Optimal Asymmetric Encryption Padding) which provides better security.
+
+**Compliant code:**
+
+```ballerina
+byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey, crypto:OAEPwithMD5andMGF1);
+```
+
+OAEP such as OAEPwithMD5andMGF1, OAEPWithSHA1AndMGF1, OAEPWithSHA256AndMGF1, OAEPwithSHA384andMGF1, and OAEPwithSHA512andMGF1 should be used for RSA encryption to enhance security.
+
+## Additional Resources
+
+- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
+- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
+- OWASP - [Top 10 2017 Category A6 - Security Misconfiguration](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration)
+- OWASP - [Mobile AppSec Verification Standard - Cryptography Requirements](https://mas.owasp.org/checklists/MASVS-CRYPTO/)
+- OWASP - [Mobile Top 10 2016 Category M5 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography)
+- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
+- CWE - [CWE-327 - Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327)
+- CWE - [CWE-780 - Use of RSA Algorithm without OAEP](https://cwe.mitre.org/data/definitions/780)
+- [CERT, MSC61-J.](https://wiki.sei.cmu.edu/confluence/x/hDdGBQ) - Do not use insecure or weak cryptographic algorithms
+
+### 11.2 Avoid using fast hashing algorithms
+
+Storing passwords in plaintext or using fast hashing algorithms creates significant security vulnerabilities. If an attacker gains access to your database, plaintext passwords are immediately compromised. Similarly, passwords hashed with fast algorithms (like MD5, SHA-1, or SHA-256 without sufficient iterations) can be rapidly cracked using modern hardware.
+
+## 11.2.1. Why this is an issue?
+
+When using PBKDF2 (Password-Based Key Derivation Function 2), the iteration count is critical for security. Higher iteration counts increase the computational effort required to hash passwords, making brute-force attacks more difficult and time-consuming.
+
+Following are the OWASP recommended parameters:
+
+For BCrypt:
+
+- Use a work factor of 10 or more
+- Only use BCrypt for password storage in legacy systems where Argon2 and scrypt are not available
+- Be aware of BCrypt's 72-byte password length limit
+
+For Argon2:
+
+- Use the Argon2id variant (which Ballerina implements)
+- Minimum configuration of 19 MiB (19,456 KB) of memory
+- An iteration count of at least 2
+- At least 1 degree of parallelism (this is enforced by Ballerina)
+
+For PBKDF2:
+
+- PBKDF2-HMAC-SHA1: 1,300,000 iterations
+- PBKDF2-HMAC-SHA256: 600,000 iterations (recommended by NIST)
+- PBKDF2-HMAC-SHA512: 210,000 iterations
+
+If performance constraints make these recommendations impractical, the iteration count should never be lower than 100,000.
+
+## 11.2.2. What is the potential impact?
+
+The security risks of using fast hashing algorithms include:
+
+- Password databases become vulnerable to brute-force attacks
+- Dictionary attacks can quickly test common passwords
+- Rainbow table attacks can reverse hash values
+- GPU-accelerated cracking tools can process billions of hashes per second
+- Credential stuffing attacks using compromised password lists
+
+## 11.2.3. How can I fix this?
+
+Use secure password hashing algorithms with appropriate parameters that provide sufficient computational cost to resist brute-force attacks.
+
+### 11.2.3.1 BCrypt Hashing Example
+
+**Non-compliant code:**
+
+```ballerina
+public function main() returns error? {
+    string password = "mySecurePassword123";
+    // Using insufficient work factor
+    string hashedPassword = check crypto:hashBcrypt(password, 4);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+Using BCrypt with a work factor below 10 is insufficient and vulnerable to brute-force attacks.
+
+**Compliant code:**
+
+```ballerina
+public function hashPassword() returns error? {
+    string password = "mySecurePassword123";
+    // Using sufficient work factor (14 or higher for better security)
+    string hashedPassword = check crypto:hashBcrypt(password, 14);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+### 11.2.3.2 Argon2 Hashing Example
+
+**Non-compliant code:**
+
+```ballerina
+public function main() returns error? {
+    string password = "mySecurePassword123";
+    // Using insufficient memory configuration
+    string hashedPassword = check crypto:hashArgon2(password, memory = 4096);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+Using Argon2 with insufficient memory (less than 19,456 KB) makes it vulnerable to attacks.
+
+**Compliant code:**
+
+```ballerina
+public function hashPassword() returns error? {
+    string password = "mySecurePassword123";
+    // Using recommended parameters: sufficient memory, iterations, and parallelism
+    string hashedPassword = check crypto:hashArgon2(password, iterations = 3, memory = 65536, parallelism = 4);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+### 11.2.3.3 PBKDF2 Hashing Example
+
+**Non-compliant code:**
+
+```ballerina
+public function main() returns error? {
+    string password = "mySecurePassword123";
+    // Using default settings with insufficient iterations
+    string hashedPassword = check crypto:hashPbkdf2(password);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+Using PBKDF2 with insufficient iterations (default 10,000) is vulnerable to brute-force attacks.
+
+**Compliant code:**
+
+```ballerina
+public function hashPassword() returns error? {
+    string password = "mySecurePassword123";
+    // Using sufficient iterations as recommended by NIST
+    string hashedPassword = check crypto:hashPbkdf2(password, iterations = 600000, algorithm = crypto:SHA256);
+    io:println("Hashed Password: ", hashedPassword);
+}
+```
+
+## 11.2.4 Additional Resources
+
+- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
+- OWASP - [Top 10 2021 Category A4 - Insecure Design](https://owasp.org/Top10/A04_2021-Insecure_Design/)
+- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
+- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
+- CWE - [CWE-256 - Plaintext Storage of a Password](https://cwe.mitre.org/data/definitions/256)
+- CWE - [CWE-916 - Use of Password Hash With Insufficient Computational Effort](https://cwe.mitre.org/data/definitions/916)
+- STIG Viewer - [Application Security and Development: V-222542](https://stigviewer.com/stigs/application_security_and_development/2024-12-06/finding/V-222542) - The application must only store cryptographic representations of passwords.
+
+### 11.3 Avoid reusing counter mode initialization vectors
+
+When using encryption algorithms in counter mode (such as AES-GCM, AES-CCM, or AES-CTR), initialization vectors (IVs) or nonces should never be reused with the same encryption key. Reusing IVs with the same key can completely compromise the security of the encryption.
+
+## 11.3.1. Why this is an issue?
+
+Counter mode encryption relies on unique initialization vectors to ensure security. When the same IV is used with the same encryption key for different plaintexts, it creates serious vulnerabilities that can lead to:
+
+- Exposure of encrypted data
+- Ability for attackers to forge authenticated messages
+- Recovery of the authentication key in some cases
+- Disclosure of plaintext by XORing two ciphertexts created with the same IV and key
+
+In modes like GCM (Galois Counter Mode), the initialization vector must be unique for each encryption operation. When an IV is reused, an attacker who observes multiple encrypted messages can perform cryptanalysis to recover the plaintext or even the encryption key.
+
+The security risks of reusing IVs in counter mode include:
+
+- Complete compromise of confidentiality
+- Potential loss of message authentication
+- Violation of the security guarantees provided by the encryption algorithm
+- Exposure of sensitive data even when using strong encryption algorithms
+
+## 11.3.2. What is the potential impact?
+
+Reusing initialization vectors in counter mode encryption creates critical security vulnerabilities:
+
+- **Confidentiality breach**: Attackers can XOR two ciphertexts encrypted with the same IV and key to reveal patterns in the plaintext
+- **Authentication forgery**: In authenticated encryption modes like GCM, IV reuse can allow attackers to create valid forged messages
+- **Key recovery**: In some scenarios, repeated IV usage can lead to recovery of the encryption key itself
+- **Complete system compromise**: Once the encryption is broken, all data encrypted with that key becomes vulnerable
+
+## 11.3.3. How can I fix this?
+
+Generate cryptographically secure random initialization vectors for each encryption operation and ensure they are never reused with the same key.
+
+### 11.3.3.1 AES-GCM Encryption Example
+
+**Non-compliant code:**
+
+```ballerina
+public function encryptData(string data) returns byte[]|error {
+    byte[16] initialVector = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    byte[16] key = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    byte[] dataBytes = data.toBytes();
+    return crypto:encryptAesGcm(dataBytes, key, initialVector);
+}
+```
+
+In this non-compliant example, the initialization vector is hardcoded, meaning every encryption operation uses the same IV. This completely undermines the security of AES-GCM encryption, regardless of key strength.
+
+**Compliant code:**
+
+```ballerina
+import ballerina/crypto;
+import ballerina/random;
+
+public function encryptData(string data) returns [byte[], byte[16]]|error {
+    byte[16] initialVector = [];
+    foreach int i in 0...15 {
+        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] key = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    byte[] dataBytes = data.toBytes();
+    byte[] encryptedData = check crypto:encryptAesGcm(dataBytes, key, initialVector);
+    return [encryptedData, initialVector];
+}
+```
+
+This compliant approach generates a cryptographically secure random initialization vector for each encryption operation and returns it along with the encrypted data. The IV must be stored alongside the encrypted data (but doesn't need to be kept secret) to allow for decryption later.
+
+### 11.3.3.2 AES-CBC Encryption Example
+
+**Non-compliant code:**
+
+```ballerina
+public function encryptMessage(string message) returns byte[]|error {
+    // Static nonce - this is vulnerable!
+    byte[12] nonce = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    byte[16] key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    byte[] messageBytes = message.toBytes();
+    return crypto:encryptAesCbc(messageBytes, key, nonce);
+}
+```
+
+**Compliant code:**
+
+```ballerina
+import ballerina/crypto;
+import ballerina/random;
+
+public function encryptMessage(string message) returns [byte[], byte[12]]|error {
+    // Generate unique nonce for each encryption
+    byte[12] nonce = [];
+    foreach int i in 0...11 {
+        nonce[i] = <byte>(check random:createIntInRange(0, 255));
+    }
+    byte[16] key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    byte[] messageBytes = message.toBytes();
+    byte[] encryptedData = check crypto:encryptAesCbc(messageBytes, key, nonce);
+    return [encryptedData, nonce];
+}
+```
+
+## 11.3.4 Additional Resources
+
+- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
+- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
+- OWASP - [Mobile AppSec Verification Standard - Cryptography Requirements](https://mas.owasp.org/checklists/MASVS-CRYPTO/)
+- OWASP - [Mobile Top 10 2016 Category M5 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography)
+- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
+- CWE - [CWE-323 - Reusing a Nonce, Key Pair in Encryption](https://cwe.mitre.org/data/definitions/323)
+- [NIST, SP-800-38A](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf) - Recommendation for Block Cipher Modes of Operation
+- [NIST, SP-800-38C](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf) - Recommendation for Block Cipher Modes of Operation: The CCM Mode for Authentication and Confidentiality
+- [NIST, SP-800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf) - Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC
+
 
 ## 11. Static Code Rules
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -22,151 +22,91 @@ The conforming implementation of the specification is released and included in t
 
 1. [Overview](#1-overview)
 2. [Hash](#2-hash)
-    - 2.1. [MD5](#21-md5)
-    - 2.2. [SHA1](#22-sha1)
-    - 2.3. [SHA256](#23-sha256)
-    - 2.4. [SHA384](#24-sha384)
-    - 2.5. [SHA512](#25-sha512)
-    - 2.6. [CRC32B](#26-crc32b)
-    - 2.7. [KECCAK256](#27-keccak256)
-    - 2.1. [MD5](#21-md5)
-    - 2.2. [SHA1](#22-sha1)
-    - 2.3. [SHA256](#23-sha256)
-    - 2.4. [SHA384](#24-sha384)
-    - 2.5. [SHA512](#25-sha512)
-    - 2.6. [CRC32B](#26-crc32b)
-    - 2.7. [KECCAK256](#27-keccak256)
+   - 2.1. [MD5](#21-md5)
+   - 2.2. [SHA1](#22-sha1)
+   - 2.3. [SHA256](#23-sha256)
+   - 2.4. [SHA384](#24-sha384)
+   - 2.5. [SHA512](#25-sha512)
+   - 2.6. [CRC32B](#26-crc32b)
+   - 2.7. [KECCAK256](#27-keccak256)
 3. [HMAC](#3-hmac)
-    - 3.1. [MD5](#31-md5)
-    - 3.2. [SHA1](#32-sha1)
-    - 3.3. [SHA256](#33-sha256)
-    - 3.4. [SHA384](#34-sha384)
-    - 3.5. [SHA512](#35-sha512)
+   - 3.1. [MD5](#31-md5)
+   - 3.2. [SHA1](#32-sha1)
+   - 3.3. [SHA256](#33-sha256)
+   - 3.4. [SHA384](#34-sha384)
+   - 3.5. [SHA512](#35-sha512)
 4. [Decode private/public key](#4-decode-privatepublic-key)
-    - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
-    - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
-    - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
-    - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
-    - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
-    - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
-    - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
-    - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
-    - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
-    - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
-    - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
-    - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
-    - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
-    - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
-    - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
-    - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
-    - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
-    - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
-    - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
+   - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
+   - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
+   - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
+   - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
+   - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
+   - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
+   - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
+   - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
+   - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
+   - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
+   - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
+   - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
+   - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
+   - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
+   - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
+   - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
+   - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
+   - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
+   - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
 5. [Encrypt-Decrypt](#5-encrypt-decrypt)
-    - 5.1. [Encryption](#51-encryption)
-        - 5.1.1. [RSA](#511-rsa)
-        - 5.1.2. [AES-CBC](#512-aes-cbc)
-        - 5.1.3. [AES-ECB](#513-aes-ecb)
-        - 5.1.4. [AES-GCM](#514-aes-gcm)
-        - 5.1.5. [PGP](#515-pgp)
-    - 5.2. [Decryption](#52-decryption)
-        - 5.2.1. [RSA-ECB](#521-rsa-ecb)
-        - 5.2.2. [AES-CBC](#522-aes-cbc)
-        - 5.2.3. [AES-ECB](#523-aes-ecb)
-        - 5.2.4. [AES-GCM](#524-aes-gcm)
-        - 5.2.5. [PGP](#525-pgp)
-    - 3.1. [MD5](#31-md5)
-    - 3.2. [SHA1](#32-sha1)
-    - 3.3. [SHA256](#33-sha256)
-    - 3.4. [SHA384](#34-sha384)
-    - 3.5. [SHA512](#35-sha512)
-4. [Decode private/public key](#4-decode-privatepublic-key)
-    - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
-    - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
-    - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
-    - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
-    - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
-    - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
-    - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
-    - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
-    - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
-    - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
-    - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
-    - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
-    - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
-    - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
-    - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
-    - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
-    - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
-    - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
-    - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
-5. [Encrypt-Decrypt](#5-encrypt-decrypt)
-    - 5.1. [Encryption](#51-encryption)
-        - 5.1.1. [RSA](#511-rsa)
-        - 5.1.2. [AES-CBC](#512-aes-cbc)
-        - 5.1.3. [AES-ECB](#513-aes-ecb)
-        - 5.1.4. [AES-GCM](#514-aes-gcm)
-        - 5.1.5. [PGP](#515-pgp)
-    - 5.2. [Decryption](#52-decryption)
-        - 5.2.1. [RSA-ECB](#521-rsa-ecb)
-        - 5.2.2. [AES-CBC](#522-aes-cbc)
-        - 5.2.3. [AES-ECB](#523-aes-ecb)
-        - 5.2.4. [AES-GCM](#524-aes-gcm)
-        - 5.2.5. [PGP](#525-pgp)
+   - 5.1. [Encryption](#51-encryption)
+     - 5.1.1. [RSA](#511-rsa)
+     - 5.1.2. [AES-CBC](#512-aes-cbc)
+     - 5.1.3. [AES-ECB](#513-aes-ecb)
+     - 5.1.4. [AES-GCM](#514-aes-gcm)
+     - 5.1.5. [PGP](#515-pgp)
+   - 5.2. [Decryption](#52-decryption)
+     - 5.2.1. [RSA-ECB](#521-rsa-ecb)
+     - 5.2.2. [AES-CBC](#522-aes-cbc)
+     - 5.2.3. [AES-ECB](#523-aes-ecb)
+     - 5.2.4. [AES-GCM](#524-aes-gcm)
+     - 5.2.5. [PGP](#525-pgp)
 6. [Sign and Verify](#6-sign-and-verify)
-    * 6.1. [Sign messages](#61-sign-messages)
-      * 6.1.1. [RSA-MD5](#611-rsa-md5)
-      * 6.1.2. [RSA-SHA1](#612-rsa-sha1)
-      * 6.1.3. [RSA-SHA256](#613-rsa-sha256)
-      * 6.1.4. [RSA-SHA384](#614-rsa-sha384)
-      * 6.1.5. [RSA-SHA512](#615-rsa-sha512)
-      * 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
-      * 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
-      * 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
-      * 6.1.9. [ML-DSA-65](#619-mldsa65)
-   * 6.2. [Verify signature](#62-verify-signature)
-       * 6.2.1. [RSA-MD5](#621-rsa-md5)
-       * 6.2.2. [RSA-SHA1](#622-rsa-sha1)
-       * 6.2.3. [RSA-SHA256](#623-rsa-sha256)
-       * 6.2.4. [RSA-SHA384](#624-rsa-sha384)
-       * 6.2.5. [RSA-SHA512](#625-rsa-sha512)
-       * 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
-       * 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
-       * 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
-       * 6.2.9. [ML-DSA-65](#629-mldsa65)
+   - 6.1. [Sign messages](#61-sign-messages)
+     - 6.1.1. [RSA-MD5](#611-rsa-md5)
+     - 6.1.2. [RSA-SHA1](#612-rsa-sha1)
+     - 6.1.3. [RSA-SHA256](#613-rsa-sha256)
+     - 6.1.4. [RSA-SHA384](#614-rsa-sha384)
+     - 6.1.5. [RSA-SHA512](#615-rsa-sha512)
+     - 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
+     - 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
+     - 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
+     - 6.1.9. [ML-DSA-65](#619-mldsa65)
+   - 6.2. [Verify signature](#62-verify-signature)
+     - 6.2.1. [RSA-MD5](#621-rsa-md5)
+     - 6.2.2. [RSA-SHA1](#622-rsa-sha1)
+     - 6.2.3. [RSA-SHA256](#623-rsa-sha256)
+     - 6.2.4. [RSA-SHA384](#624-rsa-sha384)
+     - 6.2.5. [RSA-SHA512](#625-rsa-sha512)
+     - 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
+     - 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
+     - 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
+     - 6.2.9. [ML-DSA-65](#629-mldsa65)
 7. [Key Derivation Function (KDF)](#7-key-derivation-function-kdf)
-    - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
-    - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
+   - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
 8. [Key Exchange Mechanism (KEM)](#8-key-exchange-mechanism-kem)
-    - 8.1 [Encapsulation](#81-encapsulation)
-        - 8.1.1 [RSA-KEM](#811-rsa-kem)
-        - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
-        - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
-    - 8.2 [Decapsulation](#81-encapsulation)
-        - 8.2.1 [RSA-KEM](#821-rsa-kem)
-        - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
-        - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
-    - 8.1 [Encapsulation](#81-encapsulation)
-        - 8.1.1 [RSA-KEM](#811-rsa-kem)
-        - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
-        - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
-    - 8.2 [Decapsulation](#81-encapsulation)
-        - 8.2.1 [RSA-KEM](#821-rsa-kem)
-        - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
-        - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
+   - 8.1 [Encapsulation](#81-encapsulation)
+     - 8.1.1 [RSA-KEM](#811-rsa-kem)
+     - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
+     - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
+   - 8.2 [Decapsulation](#81-encapsulation)
+     - 8.2.1 [RSA-KEM](#821-rsa-kem)
+     - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
+     - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
 9. [Hybrid Public Key Encryption (HPKE)](#9-hybrid-public-key-encryption-hpke)
-    - 9.1 [Encrypt](#91-encrypt)
-        - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
-        - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
-    - 9.2 [Decrypt](#92-decrypt)
-        - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
-        - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
-    - 9.1 [Encrypt](#91-encrypt)
-        - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
-        - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
-    - 9.2 [Decrypt](#92-decrypt)
-        - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
-        - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
+   - 9.1 [Encrypt](#91-encrypt)
+     - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
+     - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
+   - 9.2 [Decrypt](#92-decrypt)
+     - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
+     - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
 10. [Password hashing](#10-password-hashing)
     - 10.1 [BCrypt](#101-bcrypt)
     - 10.2 [Argon2](#102-argon2)
@@ -664,7 +604,7 @@ byte[] cipherText = check crypto:encryptPgp(data, publicKeyPath);
 The following encryption options can be configured in the PGP encryption.
 
 | Option                | Description                                                       | Default Value |
-|-----------------------|-------------------------------------------------------------------|---------------|
+| --------------------- | ----------------------------------------------------------------- | ------------- |
 | compressionAlgorithm  | Specifies the compression algorithm used for PGP encryption       | ZIP           |
 | symmetricKeyAlgorithm | Specifies the symmetric key algorithm used for encryption         | AES_256       |
 | armor                 | Indicates whether ASCII armor is enabled for the encrypted output | true          |
@@ -1383,7 +1323,7 @@ boolean isValid = check crypto:verifyBcrypt(password, hashedPassword1);
 Implements the Argon2id variant of the Argon2 password hashing algorithm, optimized for both high memory usage and GPU resistance.
 
 ```ballerina
-public isolated function hashArgon2(string password, int iterations = 3, 
+public isolated function hashArgon2(string password, int iterations = 3,
     int memory = 65536, int parallelism = 4) returns string|Error
 ```
 
@@ -1467,353 +1407,7 @@ boolean isValid = check crypto:verifyPbkdf2(password, hashedPassword);
 The following static code rules are applied to the Crypto module.
 
 | Id                 | Kind          | Description                                                                                                       |
-|--------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
-| ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes) |
-| ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)                                   |
-| ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)       |
-
-### 11.1 Avoid using insecure cipher modes or padding schemes
-
-Using weak or outdated encryption modes and padding schemes can compromise the security of encrypted data, even when strong algorithms are used.
-
-## 11.1.1. Why this is an issue?
-
-Encryption algorithms are essential for protecting sensitive information and ensuring secure communications. When implementing encryption, it's critical to select not only strong algorithms but also secure modes of operation and padding schemes. Using weak or outdated encryption modes can compromise the security of otherwise strong algorithms.
-
-The security risks of using weak encryption modes include:
-
-- Data confidentiality breaches where encrypted content becomes readable
-- Modification of encrypted data without detection
-- Pattern recognition in encrypted data that reveals information about the plaintext
-- Replay attacks where valid encrypted data is reused maliciously
-- Known-plaintext attacks that can reveal encryption keys
-
-## 11.1.2. What is the potential impact?
-
-Common vulnerable patterns include:
-
-- Using ECB (Electronic Codebook) mode which doesn't hide data patterns
-- Implementing CBC (Cipher Block Chaining) without integrity checks
-- Using RSA encryption without proper padding schemes
-- Relying on outdated padding methods like PKCS1v1.5
-- Using stream ciphers with insufficient initialization vectors
-
-## 11.1.3. How can I fix this?
-
-Choose secure encryption modes and padding schemes that provide both confidentiality and integrity protection.
-
-### 11.1.3.1 AES Encryption Example
-
-**Non-compliant code :**
-
-```ballerina
-byte[] cipherText = check crypto:encryptAesEcb(data, key);
-```
-
-For AES, the weakest mode is ECB (Electronic Codebook). Repeated blocks of data are encrypted to the same value, making them easy to identify and reducing the difficulty of recovering the original cleartext.
-
-```ballerina
-byte[] cipherText = check crypto:encryptAesCbc(data, key, initialVector);
-```
-
-Unauthenticated modes such as CBC (Cipher Block Chaining) may be used but are prone to attacks that manipulate the ciphertext (like padding oracle attacks). They must be used with caution and additional integrity checks.
-
-**Compliant code:**
-
-```ballerina
-byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
-```
-
-AES-GCM (Galois/Counter Mode) provides authenticated encryption, ensuring both confidentiality and integrity of the encrypted data.
-
-### 11.1.3.2 RSA Encryption Example
-
-**Non-compliant code :**
-
-```ballerina
-// Default padding is PKCS1
-byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
-
-cipherText = check crypto:encryptRsaEcb(data, publicKey, crypto:PKCS1);
-```
-
-For RSA, avoid using PKCS1v1.5 padding as it is vulnerable to various attacks. Instead, use OAEP (Optimal Asymmetric Encryption Padding) which provides better security.
-
-**Compliant code:**
-
-```ballerina
-byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey, crypto:OAEPwithMD5andMGF1);
-```
-
-OAEP such as OAEPwithMD5andMGF1, OAEPWithSHA1AndMGF1, OAEPWithSHA256AndMGF1, OAEPwithSHA384andMGF1, and OAEPwithSHA512andMGF1 should be used for RSA encryption to enhance security.
-
-## Additional Resources
-
-- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
-- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
-- OWASP - [Top 10 2017 Category A6 - Security Misconfiguration](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration)
-- OWASP - [Mobile AppSec Verification Standard - Cryptography Requirements](https://mas.owasp.org/checklists/MASVS-CRYPTO/)
-- OWASP - [Mobile Top 10 2016 Category M5 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography)
-- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
-- CWE - [CWE-327 - Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327)
-- CWE - [CWE-780 - Use of RSA Algorithm without OAEP](https://cwe.mitre.org/data/definitions/780)
-- [CERT, MSC61-J.](https://wiki.sei.cmu.edu/confluence/x/hDdGBQ) - Do not use insecure or weak cryptographic algorithms
-
-### 11.2 Avoid using fast hashing algorithms
-
-Storing passwords in plaintext or using fast hashing algorithms creates significant security vulnerabilities. If an attacker gains access to your database, plaintext passwords are immediately compromised. Similarly, passwords hashed with fast algorithms (like MD5, SHA-1, or SHA-256 without sufficient iterations) can be rapidly cracked using modern hardware.
-
-## 11.2.1. Why this is an issue?
-
-When using PBKDF2 (Password-Based Key Derivation Function 2), the iteration count is critical for security. Higher iteration counts increase the computational effort required to hash passwords, making brute-force attacks more difficult and time-consuming.
-
-Following are the OWASP recommended parameters:
-
-For BCrypt:
-
-- Use a work factor of 10 or more
-- Only use BCrypt for password storage in legacy systems where Argon2 and scrypt are not available
-- Be aware of BCrypt's 72-byte password length limit
-
-For Argon2:
-
-- Use the Argon2id variant (which Ballerina implements)
-- Minimum configuration of 19 MiB (19,456 KB) of memory
-- An iteration count of at least 2
-- At least 1 degree of parallelism (this is enforced by Ballerina)
-
-For PBKDF2:
-
-- PBKDF2-HMAC-SHA1: 1,300,000 iterations
-- PBKDF2-HMAC-SHA256: 600,000 iterations (recommended by NIST)
-- PBKDF2-HMAC-SHA512: 210,000 iterations
-
-If performance constraints make these recommendations impractical, the iteration count should never be lower than 100,000.
-
-## 11.2.2. What is the potential impact?
-
-The security risks of using fast hashing algorithms include:
-
-- Password databases become vulnerable to brute-force attacks
-- Dictionary attacks can quickly test common passwords
-- Rainbow table attacks can reverse hash values
-- GPU-accelerated cracking tools can process billions of hashes per second
-- Credential stuffing attacks using compromised password lists
-
-## 11.2.3. How can I fix this?
-
-Use secure password hashing algorithms with appropriate parameters that provide sufficient computational cost to resist brute-force attacks.
-
-### 11.2.3.1 BCrypt Hashing Example
-
-**Non-compliant code:**
-
-```ballerina
-public function main() returns error? {
-    string password = "mySecurePassword123";
-    // Using insufficient work factor
-    string hashedPassword = check crypto:hashBcrypt(password, 4);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-Using BCrypt with a work factor below 10 is insufficient and vulnerable to brute-force attacks.
-
-**Compliant code:**
-
-```ballerina
-public function hashPassword() returns error? {
-    string password = "mySecurePassword123";
-    // Using sufficient work factor (14 or higher for better security)
-    string hashedPassword = check crypto:hashBcrypt(password, 14);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-### 11.2.3.2 Argon2 Hashing Example
-
-**Non-compliant code:**
-
-```ballerina
-public function main() returns error? {
-    string password = "mySecurePassword123";
-    // Using insufficient memory configuration
-    string hashedPassword = check crypto:hashArgon2(password, memory = 4096);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-Using Argon2 with insufficient memory (less than 19,456 KB) makes it vulnerable to attacks.
-
-**Compliant code:**
-
-```ballerina
-public function hashPassword() returns error? {
-    string password = "mySecurePassword123";
-    // Using recommended parameters: sufficient memory, iterations, and parallelism
-    string hashedPassword = check crypto:hashArgon2(password, iterations = 3, memory = 65536, parallelism = 4);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-### 11.2.3.3 PBKDF2 Hashing Example
-
-**Non-compliant code:**
-
-```ballerina
-public function main() returns error? {
-    string password = "mySecurePassword123";
-    // Using default settings with insufficient iterations
-    string hashedPassword = check crypto:hashPbkdf2(password);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-Using PBKDF2 with insufficient iterations (default 10,000) is vulnerable to brute-force attacks.
-
-**Compliant code:**
-
-```ballerina
-public function hashPassword() returns error? {
-    string password = "mySecurePassword123";
-    // Using sufficient iterations as recommended by NIST
-    string hashedPassword = check crypto:hashPbkdf2(password, iterations = 600000, algorithm = crypto:SHA256);
-    io:println("Hashed Password: ", hashedPassword);
-}
-```
-
-## 11.2.4 Additional Resources
-
-- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
-- OWASP - [Top 10 2021 Category A4 - Insecure Design](https://owasp.org/Top10/A04_2021-Insecure_Design/)
-- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
-- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
-- CWE - [CWE-256 - Plaintext Storage of a Password](https://cwe.mitre.org/data/definitions/256)
-- CWE - [CWE-916 - Use of Password Hash With Insufficient Computational Effort](https://cwe.mitre.org/data/definitions/916)
-- STIG Viewer - [Application Security and Development: V-222542](https://stigviewer.com/stigs/application_security_and_development/2024-12-06/finding/V-222542) - The application must only store cryptographic representations of passwords.
-
-### 11.3 Avoid reusing counter mode initialization vectors
-
-When using encryption algorithms in counter mode (such as AES-GCM, AES-CCM, or AES-CTR), initialization vectors (IVs) or nonces should never be reused with the same encryption key. Reusing IVs with the same key can completely compromise the security of the encryption.
-
-## 11.3.1. Why this is an issue?
-
-Counter mode encryption relies on unique initialization vectors to ensure security. When the same IV is used with the same encryption key for different plaintexts, it creates serious vulnerabilities that can lead to:
-
-- Exposure of encrypted data
-- Ability for attackers to forge authenticated messages
-- Recovery of the authentication key in some cases
-- Disclosure of plaintext by XORing two ciphertexts created with the same IV and key
-
-In modes like GCM (Galois Counter Mode), the initialization vector must be unique for each encryption operation. When an IV is reused, an attacker who observes multiple encrypted messages can perform cryptanalysis to recover the plaintext or even the encryption key.
-
-The security risks of reusing IVs in counter mode include:
-
-- Complete compromise of confidentiality
-- Potential loss of message authentication
-- Violation of the security guarantees provided by the encryption algorithm
-- Exposure of sensitive data even when using strong encryption algorithms
-
-## 11.3.2. What is the potential impact?
-
-Reusing initialization vectors in counter mode encryption creates critical security vulnerabilities:
-
-- **Confidentiality breach**: Attackers can XOR two ciphertexts encrypted with the same IV and key to reveal patterns in the plaintext
-- **Authentication forgery**: In authenticated encryption modes like GCM, IV reuse can allow attackers to create valid forged messages
-- **Key recovery**: In some scenarios, repeated IV usage can lead to recovery of the encryption key itself
-- **Complete system compromise**: Once the encryption is broken, all data encrypted with that key becomes vulnerable
-
-## 11.3.3. How can I fix this?
-
-Generate cryptographically secure random initialization vectors for each encryption operation and ensure they are never reused with the same key.
-
-### 11.3.3.1 AES-GCM Encryption Example
-
-**Non-compliant code:**
-
-```ballerina
-public function encryptData(string data) returns byte[]|error {
-    byte[16] initialVector = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    byte[16] key = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-    byte[] dataBytes = data.toBytes();
-    return crypto:encryptAesGcm(dataBytes, key, initialVector);
-}
-```
-
-In this non-compliant example, the initialization vector is hardcoded, meaning every encryption operation uses the same IV. This completely undermines the security of AES-GCM encryption, regardless of key strength.
-
-**Compliant code:**
-
-```ballerina
-import ballerina/crypto;
-import ballerina/random;
-
-public function encryptData(string data) returns [byte[], byte[16]]|error {
-    byte[16] initialVector = [];
-    foreach int i in 0...15 {
-        initialVector[i] = <byte>(check random:createIntInRange(0, 255));
-    }
-    byte[16] key = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-    byte[] dataBytes = data.toBytes();
-    byte[] encryptedData = check crypto:encryptAesGcm(dataBytes, key, initialVector);
-    return [encryptedData, initialVector];
-}
-```
-
-This compliant approach generates a cryptographically secure random initialization vector for each encryption operation and returns it along with the encrypted data. The IV must be stored alongside the encrypted data (but doesn't need to be kept secret) to allow for decryption later.
-
-### 11.3.3.2 AES-CBC Encryption Example
-
-**Non-compliant code:**
-
-```ballerina
-public function encryptMessage(string message) returns byte[]|error {
-    // Static nonce - this is vulnerable!
-    byte[12] nonce = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-    byte[16] key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    byte[] messageBytes = message.toBytes();
-    return crypto:encryptAesCbc(messageBytes, key, nonce);
-}
-```
-
-**Compliant code:**
-
-```ballerina
-import ballerina/crypto;
-import ballerina/random;
-
-public function encryptMessage(string message) returns [byte[], byte[12]]|error {
-    // Generate unique nonce for each encryption
-    byte[12] nonce = [];
-    foreach int i in 0...11 {
-        nonce[i] = <byte>(check random:createIntInRange(0, 255));
-    }
-    byte[16] key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    byte[] messageBytes = message.toBytes();
-    byte[] encryptedData = check crypto:encryptAesCbc(messageBytes, key, nonce);
-    return [encryptedData, nonce];
-}
-```
-
-## 11.3.4 Additional Resources
-
-- OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
-- OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
-- OWASP - [Mobile AppSec Verification Standard - Cryptography Requirements](https://mas.owasp.org/checklists/MASVS-CRYPTO/)
-- OWASP - [Mobile Top 10 2016 Category M5 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography)
-- OWASP - [Mobile Top 10 2024 Category M10 - Insufficient Cryptography](https://owasp.org/www-project-mobile-top-10/2023-risks/m10-insufficient-cryptography)
-- CWE - [CWE-323 - Reusing a Nonce, Key Pair in Encryption](https://cwe.mitre.org/data/definitions/323)
-- [NIST, SP-800-38A](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf) - Recommendation for Block Cipher Modes of Operation
-- [NIST, SP-800-38C](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf) - Recommendation for Block Cipher Modes of Operation: The CCM Mode for Authentication and Confidentiality
-- [NIST, SP-800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf) - Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC
-
-
-## 11. Static Code Rules
-
-The following static code rules are applied to the Crypto module.
-
-| Id                 | Kind          | Description                                                                                                       |
-|--------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
+| ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes) |
 | ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)                                   |
 | ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)       |

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -5,7 +5,6 @@ _Reviewers_: @shafreenAnfar
 _Created_: 2022/08/23  
 _Updated_: 2025/01/20  
 _Edition_: Swan Lake
-_Edition_: Swan Lake
 
 ## Introduction
 
@@ -19,104 +18,92 @@ The conforming implementation of the specification is released and included in t
 
 ## Contents
 
-
 1. [Overview](#1-overview)
 2. [Hash](#2-hash)
-   - 2.1. [MD5](#21-md5)
-   - 2.2. [SHA1](#22-sha1)
-   - 2.3. [SHA256](#23-sha256)
-   - 2.4. [SHA384](#24-sha384)
-   - 2.5. [SHA512](#25-sha512)
-   - 2.6. [CRC32B](#26-crc32b)
-   - 2.7. [KECCAK256](#27-keccak256)
+    - 2.1. [MD5](#21-md5)
+    - 2.2. [SHA1](#22-sha1)
+    - 2.3. [SHA256](#23-sha256)
+    - 2.4. [SHA384](#24-sha384)
+    - 2.5. [SHA512](#25-sha512)
+    - 2.6. [CRC32B](#26-crc32b)
+    - 2.7. [KECCAK256](#27-keccak256)
 3. [HMAC](#3-hmac)
-   - 3.1. [MD5](#31-md5)
-   - 3.2. [SHA1](#32-sha1)
-   - 3.3. [SHA256](#33-sha256)
-   - 3.4. [SHA384](#34-sha384)
-   - 3.5. [SHA512](#35-sha512)
+    - 3.1. [MD5](#31-md5)
+    - 3.2. [SHA1](#32-sha1)
+    - 3.3. [SHA256](#33-sha256)
+    - 3.4. [SHA384](#34-sha384)
+    - 3.5. [SHA512](#35-sha512)
 4. [Decode private/public key](#4-decode-privatepublic-key)
-   - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
-   - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
-   - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
-   - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
-   - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
-   - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
-   - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
-   - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
-   - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
-   - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
-   - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
-   - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
-   - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
-   - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
-   - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
-   - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
-   - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
-   - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
-   - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
+    - 4.1. [Decode RSA Private key from PKCS12 file](#41-decode-rsa-private-key-from-pkcs12-file)
+    - 4.2. [Decode RSA Private key using Private key and Password](#42-decode-rsa-private-key-using-private-key-and-password)
+    - 4.3. [Decode RSA Private key using Private key content and Password](#43-decode-rsa-private-key-using-private-key-content-and-password)
+    - 4.4. [Decode RSA Public key from PKCS12 file](#44-decode-rsa-public-key-from-pkcs12-file)
+    - 4.5. [Decode RSA Public key from the certificate file](#45-decode-rsa-public-key-from-the-certificate-file)
+    - 4.6. [Decode RSA Public key from the certificate content](#46-decode-rsa-public-key-from-the-certificate-content)
+    - 4.7. [Decode EC Private key from PKCS12 file](#47-decode-ec-private-key-from-pkcs12-file)
+    - 4.8. [Decode EC Private key using Private key and Password](#48-decode-ec-private-key-using-private-key-and-password)
+    - 4.9. [Decode EC Public key from PKCS12 file](#49-decode-ec-public-key-from-pkcs12-file)
+    - 4.10. [Decode EC Public key from the certificate file](#410-decode-ec-public-key-from-the-certificate-file)
+    - 4.11. [Build RSA Public key from modulus and exponent parameters](#411-build-rsa-public-key-from-modulus-and-exponent-parameters)
+    - 4.12. [Decode ML-DSA-65 Private key from PKCS12 file](#412-decode-ml-dsa-65-private-key-from-pkcs12-file)
+    - 4.13. [Decode ML-DSA-65 Private key using Private key and Password](#413-decode-ml-dsa-65-private-key-using-private-key-and-password)
+    - 4.14. [Decode ML-DSA-65 Public key from PKCS12 file](#414-decode-ml-dsa-65-public-key-from-pkcs12-file)
+    - 4.15. [Decode ML-DSA-65 Public key from the certificate file](#415-decode-ml-dsa-65-public-key-from-the-certificate-file)
+    - 4.16. [Decode ML-KEM-768 Private key from PKCS12 file](#416-decode-ml-kem-768-private-key-from-pkcs12-file)
+    - 4.17. [Decode ML-KEM-768 Private key using Private key and Password](#417-decode-ml-kem-768-private-key-using-private-key-and-password)
+    - 4.18. [Decode ML-KEM-768 Public key from PKCS12 file](#418-decode-ml-kem-768-public-key-from-pkcs12-file)
+    - 4.19. [Decode ML-KEM-768 Public key from the certificate file](#419-decode-ml-kem-768-public-key-from-the-certificate-file)
 5. [Encrypt-Decrypt](#5-encrypt-decrypt)
-   - 5.1. [Encryption](#51-encryption)
-     - 5.1.1. [RSA](#511-rsa)
-     - 5.1.2. [AES-CBC](#512-aes-cbc)
-     - 5.1.3. [AES-ECB](#513-aes-ecb)
-     - 5.1.4. [AES-GCM](#514-aes-gcm)
-     - 5.1.5. [PGP](#515-pgp)
-   - 5.2. [Decryption](#52-decryption)
-     - 5.2.1. [RSA-ECB](#521-rsa-ecb)
-     - 5.2.2. [AES-CBC](#522-aes-cbc)
-     - 5.2.3. [AES-ECB](#523-aes-ecb)
-     - 5.2.4. [AES-GCM](#524-aes-gcm)
-     - 5.2.5. [PGP](#525-pgp)
+    - 5.1. [Encryption](#51-encryption)
+        - 5.1.1. [RSA](#511-rsa)
+        - 5.1.2. [AES-CBC](#512-aes-cbc)
+        - 5.1.3. [AES-ECB](#513-aes-ecb)
+        - 5.1.4. [AES-GCM](#514-aes-gcm)
+        - 5.1.5. [PGP](#515-pgp)
+    - 5.2. [Decryption](#52-decryption)
+        - 5.2.1. [RSA-ECB](#521-rsa-ecb)
+        - 5.2.2. [AES-CBC](#522-aes-cbc)
+        - 5.2.3. [AES-ECB](#523-aes-ecb)
+        - 5.2.4. [AES-GCM](#524-aes-gcm)
+        - 5.2.5. [PGP](#525-pgp)
 6. [Sign and Verify](#6-sign-and-verify)
-   - 6.1. [Sign messages](#61-sign-messages)
-     - 6.1.1. [RSA-MD5](#611-rsa-md5)
-     - 6.1.2. [RSA-SHA1](#612-rsa-sha1)
-     - 6.1.3. [RSA-SHA256](#613-rsa-sha256)
-     - 6.1.4. [RSA-SHA384](#614-rsa-sha384)
-     - 6.1.5. [RSA-SHA512](#615-rsa-sha512)
-     - 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
-     - 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
-     - 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
-     - 6.1.9. [ML-DSA-65](#619-mldsa65)
-   - 6.2. [Verify signature](#62-verify-signature)
-     - 6.2.1. [RSA-MD5](#621-rsa-md5)
-     - 6.2.2. [RSA-SHA1](#622-rsa-sha1)
-     - 6.2.3. [RSA-SHA256](#623-rsa-sha256)
-     - 6.2.4. [RSA-SHA384](#624-rsa-sha384)
-     - 6.2.5. [RSA-SHA512](#625-rsa-sha512)
-     - 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
-     - 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
-     - 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
-     - 6.2.9. [ML-DSA-65](#629-mldsa65)
+    - 6.1. [Sign messages](#61-sign-messages)
+        - 6.1.1. [RSA-MD5](#611-rsa-md5)
+        - 6.1.2. [RSA-SHA1](#612-rsa-sha1)
+        - 6.1.3. [RSA-SHA256](#613-rsa-sha256)
+        - 6.1.4. [RSA-SHA384](#614-rsa-sha384)
+        - 6.1.5. [RSA-SHA512](#615-rsa-sha512)
+        - 6.1.6. [SHA384withECDSA](#616-sha384withecdsa)
+        - 6.1.7. [SHA256withECDSA](#617-sha256withecdsa)
+        - 6.1.8. [ML-DSA-65](#618-ml-dsa-65)
+    - 6.2. [Verify signature](#62-verify-signature)
+        - 6.2.1. [RSA-MD5](#621-rsa-md5)
+        - 6.2.2. [RSA-SHA1](#622-rsa-sha1)
+        - 6.2.3. [RSA-SHA256](#623-rsa-sha256)
+        - 6.2.4. [RSA-SHA384](#624-rsa-sha384)
+        - 6.2.5. [RSA-SHA512](#625-rsa-sha512)
+        - 6.2.6. [SHA384withECDSA](#626-sha384withecdsa)
+        - 6.2.7. [SHA256withECDSA](#627-sha256withecdsa)
+        - 6.2.8. [ML-DSA-65](#628-ml-dsa-65)
 7. [Key Derivation Function (KDF)](#7-key-derivation-function-kdf)
-   - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
+    - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
 8. [Key Exchange Mechanism (KEM)](#8-key-exchange-mechanism-kem)
-   - 8.1 [Encapsulation](#81-encapsulation)
-     - 8.1.1 [RSA-KEM](#811-rsa-kem)
-     - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
-     - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
-   - 8.2 [Decapsulation](#81-encapsulation)
-     - 8.2.1 [RSA-KEM](#821-rsa-kem)
-     - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
-     - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
+    - 8.1 [Encapsulation](#81-encapsulation)
+        - 8.1.1 [RSA-KEM](#811-rsa-kem)
+        - 8.1.2 [ML-KEM-768](#812-ml-kem-768)
+        - 8.1.3 [RSA-KEM-ML-KEM-768](#813-rsa-kem-ml-kem-768)
+    - 8.2 [Decapsulation](#81-encapsulation)
+        - 8.2.1 [RSA-KEM](#821-rsa-kem)
+        - 8.2.2 [ML-KEM-768](#822-ml-kem-768)
+        - 8.2.3 [RSA-KEM-ML-KEM-768](#823-rsa-kem-ml-kem-768)
 9. [Hybrid Public Key Encryption (HPKE)](#9-hybrid-public-key-encryption-hpke)
-   - 9.1 [Encrypt](#91-encrypt)
-     - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
-     - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
-   - 9.2 [Decrypt](#92-decrypt)
-     - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
-     - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
+    - 9.1 [Encrypt](#91-encrypt)
+        - 9.1.1 [ML-KEM-768-HPKE](#911-ml-kem-768-hpke)
+        - 9.1.2 [RSA-KEM-ML-KEM-768-HPKE](#912-rsa-kem-ml-kem-768-hpke)
+    - 9.2 [Decrypt](#92-decrypt)
+        - 9.2.1 [ML-KEM-768-HPKE](#921-ml-kem-768-hpke)
+        - 9.2.2 [RSA-KEM-ML-KEM-768-HPKE](#922-rsa-kem-ml-kem-768-hpke)
 10. [Password hashing](#10-password-hashing)
-    - 10.1 [BCrypt](#101-bcrypt)
-    - 10.2 [Argon2](#102-argon2)
-    - 10.3 [PBKDF2](#103-pbkdf2)
-11. [Static Code Rules](#11-static-code-rules)
-    - 11.1 [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes)
-    - 11.2 [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)
-    - 11.3 [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)
-
-## 1. Overview
     - 10.1 [BCrypt](#101-bcrypt)
     - 10.2 [Argon2](#102-argon2)
     - 10.3 [PBKDF2](#103-pbkdf2)
@@ -130,15 +117,12 @@ The conforming implementation of the specification is released and included in t
 The Ballerina `crypto` library facilitates APIs to do operations like hashing, HMAC generation, checksum generation, encryption, decryption, signing data digitally, verifying digitally signed data, etc., with different cryptographic algorithms.
 
 ## 2. Hash
-## 2. Hash
 
 The `crypto` library supports generating hashes with 5 different hash algorithms MD5, SHA1, SHA256, SHA384, and SHA512. Also, it supports generating the CRC32B checksum.
 
 ### 2.1. MD5
-### 2.1. MD5
 
 This API can be used to create the MD5 hash of the given data.
-
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -147,10 +131,8 @@ byte[] hash = crypto:hashMd5(data);
 ```
 
 ### 2.2. SHA1
-### 2.2. SHA1
 
 This API can be used to create the SHA-1 hash of the given data.
-
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -159,10 +141,8 @@ byte[] hash = crypto:hashSha1(data);
 ```
 
 ### 2.3. SHA256
-### 2.3. SHA256
 
 This API can be used to create the SHA-256 hash of the given data.
-
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -171,10 +151,8 @@ byte[] hash = crypto:hashSha256(data);
 ```
 
 ### 2.4. SHA384
-### 2.4. SHA384
 
 This API can be used to create the SHA-384 hash of the given data.
-
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -183,10 +161,8 @@ byte[] hash = crypto:hashSha384(data);
 ```
 
 ### 2.5. SHA512
-### 2.5. SHA512
 
 This API can be used to create the SHA-512 hash of the given data.
-
 
 ```ballerina
 string dataString = "Hello Ballerina";
@@ -195,10 +171,8 @@ byte[] hash = crypto:hashSha512(data);
 ```
 
 ### 2.6. CRC32B
-### 2.6. CRC32B
 
 This API can be used to create the Hex-encoded CRC32B value of the given data.
-
 
 ```ballerina
 string stringData = "Hello Ballerina";
@@ -207,10 +181,8 @@ string checksum = crypto:crc32b(data);
 ```
 
 ### 2.7. KECCAK256
-### 2.7. KECCAK256
 
 This API can be used to create the Hex-encoded KECCAK-256 value of the given data.
-
 
 ```ballerina
 string stringData = "Hello Ballerina";
@@ -219,11 +191,9 @@ string checksum = crypto:hashKeccak256(data);
 ```
 
 ## 3. HMAC
-## 3. HMAC
 
 The `crypto` library supports generating HMAC with 5 different hash algorithms: MD5, SHA1, SHA256, SHA384, and SHA512.
 
-### 3.1. MD5
 ### 3.1. MD5
 
 This API can be used to create HMAC using the MD5 hash function of the given data.
@@ -237,7 +207,6 @@ byte[] hmac = check crypto:hmacMd5(data, key);
 ```
 
 ### 3.2. SHA1
-### 3.2. SHA1
 
 This API can be used to create HMAC using the SHA-1 hash function of the given data.
 
@@ -249,7 +218,6 @@ byte[] key = secret.toBytes();
 byte[] hmac = crypto:hmacSha1(data, key);
 ```
 
-### 3.3. SHA256
 ### 3.3. SHA256
 
 This API can be used to create HMAC using the SHA-256 hash function of the given data.
@@ -263,7 +231,6 @@ byte[] hmac = check crypto:hmacSha256(data, key);
 ```
 
 ### 3.4. SHA384
-### 3.4. SHA384
 
 This API can be used to create HMAC using the SHA-384 hash function of the given data.
 
@@ -275,7 +242,6 @@ byte[] key = secret.toBytes();
 byte[] hmac = check crypto:hmacSha384(data, key);
 ```
 
-### 3.5. SHA512
 ### 3.5. SHA512
 
 This API can be used to create HMAC using the SHA-512 hash function of the given data.
@@ -289,11 +255,9 @@ byte[] hmac = check crypto:hmacSha512(data, key);
 ```
 
 ## 4. Decode private/public key
-## 4. Decode private/public key
 
 The `crypto` library supports decoding the RSA private key from a `.p12` file and a key file in the `PEM` format. Also, it supports decoding a public key from a `.p12` file and a certificate file in the `X509` format. Additionally, this supports building an RSA public key with the modulus and exponent parameters.
 
-### 4.1. Decode RSA Private key from PKCS12 file
 ### 4.1. Decode RSA Private key from PKCS12 file
 
 This API can be used to decode the RSA private key from the given PKCS#12 file.
@@ -307,7 +271,6 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 ```
 
 ### 4.2. Decode RSA Private key using Private key and Password
-### 4.2. Decode RSA Private key using Private key and Password
 
 This API can be used to decode the RSA private key from the given private key and private key password.
 
@@ -317,7 +280,6 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyFile(keyFi
 ```
 
 ## 4.3. Decode RSA Private key using Private key content and Password
-## 4.3. Decode RSA Private key using Private key content and Password
 
 This API can be used to decode the RSA public key from the given public certificate content as a byte array.
 
@@ -326,7 +288,6 @@ byte[] keyContent = [45,45,45,45,45,66,69,71,73,78,...];
 crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromContent(keyContent);
 ```
 
-### 4.4. Decode RSA Public key from PKCS12 file
 ### 4.4. Decode RSA Public key from PKCS12 file
 
 This API can be used to decode the RSA public key from the given PKCS#12 archive file.
@@ -340,7 +301,6 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(trust
 ```
 
 ### 4.5. Decode RSA Public key from the certificate file
-### 4.5. Decode RSA Public key from the certificate file
 
 This API can be used to decode the RSA public key from the given public certificate file.
 
@@ -350,7 +310,6 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromCertFile(certFil
 ```
 
 ### 4.6. Decode RSA Public key from the certificate content
-### 4.6. Decode RSA Public key from the certificate content
 
 This API can be used to decode the RSA public key from the given public certificate content as a byte array.
 
@@ -359,7 +318,6 @@ byte[] certFileContent = [45,45,45,45,45,66,69,71,73,78,...];
 crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromContent(certFileContent);
 ```
 
-### 4.7. Decode EC Private key from PKCS12 file
 ### 4.7. Decode EC Private key from PKCS12 file
 
 This API can be used to decode the EC private key from the given PKCS#12 file.
@@ -373,7 +331,6 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 ```
 
 ### 4.8. Decode EC Private key using Private key and Password
-### 4.8. Decode EC Private key using Private key and Password
 
 This API can be used to decode the EC private key from the given private key and private key password.
 
@@ -382,7 +339,6 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
-### 4.9. Decode EC Public key from PKCS12 file
 ### 4.9. Decode EC Public key from PKCS12 file
 
 This API can be used to decode the RSA public key from the given PKCS#12 archive file.
@@ -396,7 +352,6 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(trustS
 ```
 
 ### 4.10. Decode EC Public key from the certificate file
-### 4.10. Decode EC Public key from the certificate file
 
 This API can be used to decode the EC public key from the given public certificate file.
 
@@ -405,7 +360,6 @@ string certFile = "/path/to/public.cert";
 crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromCertFile(certFile);
 ```
 
-### 4.11. Build RSA Public key from modulus and exponent parameters
 ### 4.11. Build RSA Public key from modulus and exponent parameters
 
 This API can be used to build the RSA public key from the given modulus and exponent parameters.
@@ -420,7 +374,6 @@ crypto:PublicKey publicKey = check crypto:buildRsaPublicKey(modulus, exponent);
 ```
 
 ### 4.12. Decode ML-DSA-65 Private key from PKCS12 file
-### 4.12. Decode ML-DSA-65 Private key from PKCS12 file
 
 This API can be used to decode the ML-DSA-65 private key from the given PKCS#12 file.
 
@@ -433,7 +386,6 @@ crypto:PrivateKey privateKey = check crypto:decodeMlDsa65PrivateKeyFromKeyStore(
 ```
 
 ### 4.13. Decode ML-DSA-65 Private key using Private key and Password
-### 4.13. Decode ML-DSA-65 Private key using Private key and Password
 
 This API can be used to decode the ML-DSA-65 private key from the given private key and private key password.
 
@@ -442,7 +394,6 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeMlDsa65PrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
-### 4.14. Decode ML-DSA-65 Public key from PKCS12 file
 ### 4.14. Decode ML-DSA-65 Public key from PKCS12 file
 
 This API can be used to decode the ML-DSA-65 public key from the given PKCS#12 archive file.
@@ -456,7 +407,6 @@ crypto:PublicKey publicKey = check crypto:decodeMlDsa65PublicKeyFromTrustStore(t
 ```
 
 ### 4.15. Decode ML-DSA-65 Public key from the certificate file
-### 4.15. Decode ML-DSA-65 Public key from the certificate file
 
 This API can be used to decode the ML-DSA-65 public key from the given public certificate file.
 
@@ -465,7 +415,6 @@ string certFile = "/path/to/public.cert";
 crypto:PublicKey publicKey = check crypto:decodeMlDsa65PublicKeyFromCertFile(certFile);
 ```
 
-### 4.16. Decode ML-KEM-768 Private key from PKCS12 file
 ### 4.16. Decode ML-KEM-768 Private key from PKCS12 file
 
 This API can be used to decode the ML-KEM-768 private key from the given PKCS#12 file.
@@ -479,7 +428,6 @@ crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyStore
 ```
 
 ### 4.17. Decode ML-KEM-768 Private key using Private key and Password
-### 4.17. Decode ML-KEM-768 Private key using Private key and Password
 
 This API can be used to decode the ML-KEM-768 private key from the given private key and private key password.
 
@@ -488,7 +436,6 @@ string keyFile = "/path/to/private.key";
 crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyFile(keyFile, "keyPassword");
 ```
 
-### 4.18. Decode ML-KEM-768 Public key from PKCS12 file
 ### 4.18. Decode ML-KEM-768 Public key from PKCS12 file
 
 This API can be used to decode the ML-KEM-768 public key from the given PKCS#12 archive file.
@@ -502,7 +449,6 @@ crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromTrustStore(
 ```
 
 ### 4.19. Decode ML-KEM-768 Public key from the certificate file
-### 4.19. Decode ML-KEM-768 Public key from the certificate file
 
 This API can be used to decode the ML-KEM-768 public key from the given public certificate file.
 
@@ -512,14 +458,11 @@ crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromCertFile(ce
 ```
 
 ## 5. Encrypt-Decrypt
-## 5. Encrypt-Decrypt
 
 The `crypto` library supports both symmetric key encryption/decryption and asymmetric key encryption/decryption. The RSA algorithm can be used for asymmetric-key encryption/decryption with the use of private and public keys. The AES algorithm can be used for symmetric-key encryption/decryption with the use of a shared key.
 
 ### 5.1. Encryption
-### 5.1. Encryption
 
-#### 5.1.1. RSA
 #### 5.1.1. RSA
 
 This API can be used to create the RSA-encrypted value of the given data.
@@ -535,7 +478,6 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
 ```
 
-#### 5.1.2. AES-CBC
 #### 5.1.2. AES-CBC
 
 This API can be used to create the AES-CBC-encrypted value for the given data.
@@ -555,7 +497,6 @@ byte[] cipherText = check crypto:encryptAesCbc(data, key, initialVector);
 ```
 
 #### 5.1.3. AES-ECB
-#### 5.1.3. AES-ECB
 
 This API can be used to create the AES-ECB-encrypted value for the given data.
 
@@ -569,7 +510,6 @@ foreach int i in 0...15 {
 byte[] cipherText = check crypto:encryptAesEcb(data, key);
 ```
 
-#### 5.1.4. AES-GCM
 #### 5.1.4. AES-GCM
 
 This API can be used to create the AES-GCM-encrypted value for the given data.
@@ -589,7 +529,6 @@ byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
 ```
 
 #### 5.1.5. PGP
-#### 5.1.5. PGP
 
 This API can be used to create the PGP-encrypted value for the given data.
 
@@ -604,7 +543,7 @@ byte[] cipherText = check crypto:encryptPgp(data, publicKeyPath);
 The following encryption options can be configured in the PGP encryption.
 
 | Option                | Description                                                       | Default Value |
-| --------------------- | ----------------------------------------------------------------- | ------------- |
+|-----------------------|-------------------------------------------------------------------|---------------|
 | compressionAlgorithm  | Specifies the compression algorithm used for PGP encryption       | ZIP           |
 | symmetricKeyAlgorithm | Specifies the symmetric key algorithm used for encryption         | AES_256       |
 | armor                 | Indicates whether ASCII armor is enabled for the encrypted output | true          |
@@ -627,9 +566,7 @@ stream<byte[], crypto:Error?>|crypto:Error encryptedStream = crypto:encryptStrea
 ```
 
 ### 5.2. Decryption
-### 5.2. Decryption
 
-#### 5.2.1. RSA-ECB
 #### 5.2.1. RSA-ECB
 
 This API can be used to create the RSA-decrypted value for the given RSA-encrypted data.
@@ -647,7 +584,6 @@ byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey);
 byte[] plainText = check crypto:decryptRsaEcb(cipherText, privateKey);
 ```
 
-#### 5.2.2. AES-CBC
 #### 5.2.2. AES-CBC
 
 This API can be used to create the AES-CBC-decrypted value for the given AES-CBC-encrypted data.
@@ -668,7 +604,6 @@ byte[] plainText = check crypto:decryptAesCbc(cipherText, key, initialVector);
 ```
 
 #### 5.2.3. AES-ECB
-#### 5.2.3. AES-ECB
 
 This API can be used to create the AES-ECB-decrypted value for the given AES-ECB-encrypted data.
 
@@ -683,7 +618,6 @@ byte[] cipherText = check crypto:encryptAesEcb(data, key);
 byte[] plainText = check crypto:decryptAesEcb(cipherText, key);
 ```
 
-#### 5.2.4. AES-GCM
 #### 5.2.4. AES-GCM
 
 This API can be used to create the AES-GCM-decrypted value for the given AES-GCM-encrypted data.
@@ -703,7 +637,6 @@ byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
 byte[] plainText = check crypto:decryptAesGcm(cipherText, key, initialVector);
 ```
 
-#### 5.2.5. PGP
 #### 5.2.5. PGP
 
 This API can be used to create the PGP-decrypted value for the given PGP-encrypted data.
@@ -728,14 +661,11 @@ stream<byte[], crypto:Error?>|crypto:Error decryptedStream = crypto:decryptStrea
 ```
 
 ## 6. Sign and Verify
-## 6. Sign and Verify
 
 The `crypto` library supports signing data using the RSA private key and verification of the signature using the RSA public key. This supports MD5, SHA1, SHA256, SHA384, and SHA512 digesting algorithms, and ML-DSA-65 post-quantum signature algorithm as well.
 
 ### 6.1. Sign messages
-### 6.1. Sign messages
 
-#### 6.1.1. RSA-MD5
 #### 6.1.1. RSA-MD5
 
 This API can be used to create the RSA-MD5 based signature value for the given data.
@@ -752,7 +682,6 @@ byte[] signature = check crypto:signRsaMd5(data, privateKey);
 ```
 
 #### 6.1.2. RSA-SHA1
-#### 6.1.2. RSA-SHA1
 
 This API can be used to create the RSA-SHA1 based signature value for the given data.
 
@@ -767,7 +696,6 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha1(data, privateKey);
 ```
 
-#### 6.1.3. RSA-SHA256
 #### 6.1.3. RSA-SHA256
 
 This API can be used to create the RSA-SHA256 based signature value for the given data.
@@ -784,7 +712,6 @@ byte[] signature = check crypto:signRsaSha256(data, privateKey);
 ```
 
 #### 6.1.4. RSA-SHA384
-#### 6.1.4. RSA-SHA384
 
 This API can be used to create the RSA-SHA384 based signature value for the given data.
 
@@ -800,7 +727,6 @@ byte[] signature = check crypto:signRsaSha384(data, privateKey);
 ```
 
 #### 6.1.5. RSA-SHA512
-#### 6.1.5. RSA-SHA512
 
 This API can be used to create the RSA-SHA512 based signature value for the given data.
 
@@ -815,22 +741,7 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha512(data, privateKey);
 ```
 
-#### 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
-
-This API can be used to create the RSASSA-PSS based signature value for the given data.
-
-```ballerina
-string input = "Hello Ballerina";
-byte[] data = input.toBytes();
-crypto:KeyStore keyStore = {
-    path: "/path/to/keyStore.p12",
-    password: "keyStorePassword"
-};
-crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
-byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
-```
-
-#### 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
+#### 6.1.6. SHA384withECDSA
 
 This API can be used to create the SHA384withECDSA based signature value for the given data.
 
@@ -845,7 +756,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha384withEcdsa(data, privateKey);
 ```
 
-#### 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
+#### 6.1.7. SHA256withECDSA
 
 This API can be used to create the SHA256withECDSA based signature value for the given data.
 
@@ -860,7 +771,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha256withEcdsa(data, privateKey);
 ```
 
-#### 6.1.9. [ML-DSA-65](#619-mldsa65)
+#### 6.1.8. ML-DSA-65
 
 This API can be used to create the ML-DSA-65 based signature value for the given data.
 
@@ -876,9 +787,7 @@ byte[] signature = check crypto:signMlDsa65(data, privateKey);
 ```
 
 ### 6.2. Verify signature
-### 6.2. Verify signature
 
-#### 6.2.1. RSA-MD5
 #### 6.2.1. RSA-MD5
 
 This API can be used to verify the RSA-MD5 based signature.
@@ -897,7 +806,6 @@ boolean validity = check crypto:verifyRsaMd5Signature(data, signature, publicKey
 ```
 
 #### 6.2.2. RSA-SHA1
-#### 6.2.2. RSA-SHA1
 
 This API can be used to verify the RSA-SHA1 based signature.
 
@@ -914,7 +822,6 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha1Signature(data, signature, publicKey);
 ```
 
-#### 6.2.3. RSA-SHA256
 #### 6.2.3. RSA-SHA256
 
 This API can be used to verify the RSA-SHA256 based signature.
@@ -933,7 +840,6 @@ boolean validity = check crypto:verifyRsaSha256Signature(data, signature, public
 ```
 
 #### 6.2.4. RSA-SHA384
-#### 6.2.4. RSA-SHA384
 
 This API can be used to verify the RSA-SHA384 based signature.
 
@@ -951,7 +857,6 @@ boolean validity = check crypto:verifyRsaSha384Signature(data, signature, public
 ```
 
 #### 6.2.5. RSA-SHA512
-#### 6.2.5. RSA-SHA512
 
 This API can be used to verify the RSA-SHA512 based signature.
 
@@ -968,24 +873,7 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha512Signature(data, signature, publicKey);
 ```
 
-#### 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
-
-This API can be used to verify the RSASSA-PSS based signature.
-
-```ballerina
-string input = "Hello Ballerina";
-byte[] data = input.toBytes();
-crypto:KeyStore keyStore = {
-    path: "/path/to/keyStore.p12",
-    password: "keyStorePassword"
-};
-crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
-byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
-crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keyStore, "keyAlias");
-boolean validity = check crypto:verifyRsaSsaPss256Signature(data, signature, publicKey);
-```
-
-#### 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
+#### 6.2.6. SHA384withECDSA
 
 This API can be used to verify the SHA384withECDSA based signature.
 
@@ -1002,7 +890,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha384withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
+#### 6.2.7. SHA256withECDSA
 
 This API can be used to verify the SHA256withECDSA based signature.
 
@@ -1019,7 +907,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha256withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.9. [ML-DSA-65](#629-mldsa65)
+#### 6.2.8. ML-DSA-65
 
 This API can be used to verify the ML-DSA-65 based signature.
 
@@ -1037,11 +925,9 @@ boolean validity = check crypto:verifyMlDsa65Signature(data, signature, publicKe
 ```
 
 ## 7. Key Derivation Function (KDF)
-## 7. Key Derivation Function (KDF)
 
 The `crypto` module supports HMAC-based Key Derivation Function (HKDF). HKDF is a key derivation function that uses a Hash-based Message Authentication Code (HMAC) to derive keys.
 
-### 7.1. HKDF-SHA256
 ### 7.1. HKDF-SHA256
 
 This API can be used to create HKDF using the SHA256 hash function of the given data.
@@ -1053,18 +939,13 @@ byte[] hash = crypto:hkdfSha256(key, 32);
 ```
 
 ## 8. Key Exchange Mechanism (KEM)
-## 8. Key Exchange Mechanism (KEM)
 
 The `crypto` module supports Key Exchange Mechanisms (KEM). It includes RSA-KEM and post-quantum ML-KEM-768 for both encapsulation and decapsulation.
 
 ### 8.1. Encapsulation
 
 #### 8.1.1. RSA-KEM
-### 8.1. Encapsulation
 
-#### 8.1.1. RSA-KEM
-
-This API can be used to create shared secret and its encapsulation using RSA-KEM function.
 This API can be used to create shared secret and its encapsulation using RSA-KEM function.
 
 ```ballerina
@@ -1078,9 +959,6 @@ crypto:EncapsulationResult encapsulationResult = check crypto:encapsulateRsaKem(
 
 #### 8.1.2. ML-KEM-768
 
-#### 8.1.2. ML-KEM-768
-
-This API can be used to create shared secret and its encapsulation using ML-KEM-768 function.
 This API can be used to create shared secret and its encapsulation using ML-KEM-768 function.
 
 ```ballerina
@@ -1094,9 +972,6 @@ crypto:EncapsulationResult encapsulationResult = check crypto:encapsulateMlKem76
 
 #### 8.1.3. RSA-KEM-ML-KEM-768
 
-#### 8.1.3. RSA-KEM-ML-KEM-768
-
-This API can be used to create shared secret and its encapsulation using RSA-KEM-ML-KEM-768 function.
 This API can be used to create shared secret and its encapsulation using RSA-KEM-ML-KEM-768 function.
 
 ```ballerina
@@ -1120,11 +995,7 @@ byte[] sharedSecret = check crypto:decapsulateRsaKemMlKem768(encapsulatedSecret,
 ### 8.2. Decapsulation
 
 #### 8.2.1. RSA-KEM
-### 8.2. Decapsulation
 
-#### 8.2.1. RSA-KEM
-
-This API can be used to decapsulate shared secret using RSA-KEM function of the given data.
 This API can be used to decapsulate shared secret using RSA-KEM function of the given data.
 
 ```ballerina
@@ -1141,9 +1012,6 @@ byte[] sharedSecret = check crypto:decapsulateRsaKem(encapsulatedSecret, private
 
 #### 8.2.2. ML-KEM-768
 
-#### 8.2.2. ML-KEM-768
-
-This API can be used to decapsulate shared secret using ML-KEM-768 function of the given data.
 This API can be used to decapsulate shared secret using ML-KEM-768 function of the given data.
 
 ```ballerina
@@ -1160,9 +1028,6 @@ byte[] sharedSecret = check crypto:decapsulateMlKem768(encapsulatedSecret, priva
 
 #### 8.2.3. RSA-KEM-ML-KEM-768
 
-#### 8.2.3. RSA-KEM-ML-KEM-768
-
-This API can be used to decapsulate shared secret using RSA-KEM-ML-KEM-768 function of the given data.
 This API can be used to decapsulate shared secret using RSA-KEM-ML-KEM-768 function of the given data.
 
 ```ballerina
@@ -1184,13 +1049,9 @@ byte[] sharedSecret = check crypto:decapsulateRsaKemMlKem768(encapsulatedSecret,
 ```
 
 ## 9. Hybrid Public Key Encryption (HPKE)
-## 9. Hybrid Public Key Encryption (HPKE)
 
 The `crypto` module supports Hybrid Public Key Encryption (HPKE). It supports post-quantum ML-KEM-768-HPKE and RSA-KEM-ML-KEM-768-HPKE for encryption and decryption.
 
-### 9.1. Encrypt
-
-#### 9.1.1. ML-KEM-768-HPKE
 ### 9.1. Encrypt
 
 #### 9.1.1. ML-KEM-768-HPKE
@@ -1207,8 +1068,6 @@ crypto:KeyStore keyStore = {
 crypto:PublicKey publicKey = check crypto:decodeMlKem768PublicKeyFromTrustStore(keyStore, "keyAlias");
 crypto:HybridEncryptionResult encryptionResult = check crypto:encryptMlKem768Hpke(data, publicKey);
 ```
-
-#### 9.1.2. RSA-KEM-ML-KEM-768-HPKE
 
 #### 9.1.2. RSA-KEM-ML-KEM-768-HPKE
 
@@ -1233,9 +1092,6 @@ crypto:HybridEncryptionResult encryptionResult = check crypto:encryptRsaKemMlKem
 ### 9.2. Decrypt
 
 #### 9.2.1. ML-KEM-768-HPKE
-### 9.2. Decrypt
-
-#### 9.2.1. ML-KEM-768-HPKE
 
 This API can be used to create the ML-KEM-768-hybrid-decrypted value of the given data.
 
@@ -1253,8 +1109,6 @@ byte[] encapsulatedKey = encryptionResult.encapsulatedSecret;
 crypto:PrivateKey privateKey = check crypto:decodeMlKem768PrivateKeyFromKeyStore(keyStore, "keyAlias", "keyStorePassword");
 byte[] decryptedData = check crypto:decryptMlKem768Hpke(cipherText, encapsulatedKey, privateKey);
 ```
-
-#### 9.2.2. RSA-KEM-ML-KEM-768-HPKE
 
 #### 9.2.2. RSA-KEM-ML-KEM-768-HPKE
 
@@ -1282,11 +1136,9 @@ byte[] decryptedData = check crypto:decryptRsaKemMlKem768Hpke(cipherText, encaps
 ```
 
 ## 10. Password Hashing
-## 10. Password Hashing
 
 The `crypto` module provides password hashing using BCrypt and Argon2id algorithms for secure password storage.
 
-### 10.1 BCrypt
 ### 10.1 BCrypt
 
 Implements the BCrypt password hashing algorithm based on the Blowfish cipher.
@@ -1297,7 +1149,6 @@ public isolated function hashBcrypt(string password, int workFactor = 12) return
 
 Parameters:
 
-
 - `password`: The plain text password to hash
 - `workFactor`: Computational complexity factor (4-31, default: 12)
 
@@ -1306,7 +1157,6 @@ public isolated function verifyBcrypt(string password, string hashedPassword) re
 ```
 
 Example:
-
 
 ```ballerina
 string password = "your-password";
@@ -1318,17 +1168,15 @@ boolean isValid = check crypto:verifyBcrypt(password, hashedPassword1);
 ```
 
 ### 10.2 Argon2
-### 10.2 Argon2
 
 Implements the Argon2id variant of the Argon2 password hashing algorithm, optimized for both high memory usage and GPU resistance.
 
 ```ballerina
-public isolated function hashArgon2(string password, int iterations = 3,
+public isolated function hashArgon2(string password, int iterations = 3, 
     int memory = 65536, int parallelism = 4) returns string|Error
 ```
 
 Parameters:
-
 
 - `password`: The plain text password to hash
 - `iterations`: Number of iterations (default: 3)
@@ -1343,7 +1191,6 @@ public isolated function verifyArgon2(string password, string hashedPassword) re
 
 Example:
 
-
 ```ballerina
 string password = "your-password";
 // Hash with default parameters
@@ -1353,7 +1200,6 @@ string hashedPassword2 = check crypto:hashArgon2(password, iterations = 4, memor
 boolean isValid = check crypto:verifyArgon2(password, hashedPassword1);
 ```
 
-### 10.3 PBKDF2
 ### 10.3 PBKDF2
 
 Implements the PBKDF2 (Password-Based Key Derivation Function 2) algorithm for password hashing.
@@ -1407,7 +1253,7 @@ boolean isValid = check crypto:verifyPbkdf2(password, hashedPassword);
 The following static code rules are applied to the Crypto module.
 
 | Id                 | Kind          | Description                                                                                                       |
-| ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+|--------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
 | ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes) |
 | ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)                                   |
 | ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)       |

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -67,24 +67,26 @@ The conforming implementation of the specification is released and included in t
         - 5.2.4. [AES-GCM](#524-aes-gcm)
         - 5.2.5. [PGP](#525-pgp)
 6. [Sign and Verify](#6-sign-and-verify)
-    - 6.1. [Sign messages](#61-sign-messages)
-        - 6.1.1. [RSA-MD5](#611-rsa-md5)
-        - 6.1.2. [RSA-SHA1](#612-rsa-sha1)
-        - 6.1.3. [RSA-SHA256](#613-rsa-sha256)
-        - 6.1.4. [RSA-SHA384](#614-rsa-sha384)
-        - 6.1.5. [RSA-SHA512](#615-rsa-sha512)
-        - 6.1.6. [SHA384withECDSA](#616-sha384withecdsa)
-        - 6.1.7. [SHA256withECDSA](#617-sha256withecdsa)
-        - 6.1.8. [ML-DSA-65](#618-ml-dsa-65)
-    - 6.2. [Verify signature](#62-verify-signature)
-        - 6.2.1. [RSA-MD5](#621-rsa-md5)
-        - 6.2.2. [RSA-SHA1](#622-rsa-sha1)
-        - 6.2.3. [RSA-SHA256](#623-rsa-sha256)
-        - 6.2.4. [RSA-SHA384](#624-rsa-sha384)
-        - 6.2.5. [RSA-SHA512](#625-rsa-sha512)
-        - 6.2.6. [SHA384withECDSA](#626-sha384withecdsa)
-        - 6.2.7. [SHA256withECDSA](#627-sha256withecdsa)
-        - 6.2.8. [ML-DSA-65](#628-ml-dsa-65)
+    * 6.1. [Sign messages](#61-sign-messages)
+      * 6.1.1. [RSA-MD5](#611-rsa-md5)
+      * 6.1.2. [RSA-SHA1](#612-rsa-sha1)
+      * 6.1.3. [RSA-SHA256](#613-rsa-sha256)
+      * 6.1.4. [RSA-SHA384](#614-rsa-sha384)
+      * 6.1.5. [RSA-SHA512](#615-rsa-sha512)
+      * 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
+      * 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
+      * 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
+      * 6.1.9. [ML-DSA-65](#619-mldsa65)
+   * 6.2. [Verify signature](#62-verify-signature)
+       * 6.2.1. [RSA-MD5](#621-rsa-md5)
+       * 6.2.2. [RSA-SHA1](#622-rsa-sha1)
+       * 6.2.3. [RSA-SHA256](#623-rsa-sha256)
+       * 6.2.4. [RSA-SHA384](#624-rsa-sha384)
+       * 6.2.5. [RSA-SHA512](#625-rsa-sha512)
+       * 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
+       * 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
+       * 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
+       * 6.2.9. [ML-DSA-65](#629-mldsa65)
 7. [Key Derivation Function (KDF)](#7-key-derivation-function-kdf)
     - 7.1. [HKDF-SHA256](#71-hkdf-sha256)
 8. [Key Exchange Mechanism (KEM)](#8-key-exchange-mechanism-kem)
@@ -741,7 +743,22 @@ crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyS
 byte[] signature = check crypto:signRsaSha512(data, privateKey);
 ```
 
-#### 6.1.6. SHA384withECDSA
+#### 6.1.6. [RSASSA-PSS-SHA256](#616-rsassa-pss-sha256)
+
+This API can be used to create the RSASSA-PSS based signature value for the given data.
+
+```ballerina
+string input = "Hello Ballerina";
+byte[] data = input.toBytes();
+crypto:KeyStore keyStore = {
+    path: "/path/to/keyStore.p12",
+    password: "keyStorePassword"
+};
+crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+```
+
+#### 6.1.7. [SHA384withECDSA](#617-sha384withecdsa)
 
 This API can be used to create the SHA384withECDSA based signature value for the given data.
 
@@ -756,7 +773,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha384withEcdsa(data, privateKey);
 ```
 
-#### 6.1.7. SHA256withECDSA
+#### 6.1.8. [SHA256withECDSA](#618-sha256withecdsa)
 
 This API can be used to create the SHA256withECDSA based signature value for the given data.
 
@@ -771,7 +788,7 @@ crypto:PrivateKey privateKey = check crypto:decodeEcPrivateKeyFromKeyStore(keySt
 byte[] signature = check crypto:signSha256withEcdsa(data, privateKey);
 ```
 
-#### 6.1.8. ML-DSA-65
+#### 6.1.9. [ML-DSA-65](#619-mldsa65)
 
 This API can be used to create the ML-DSA-65 based signature value for the given data.
 
@@ -873,7 +890,24 @@ crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keySt
 boolean validity = check crypto:verifyRsaSha512Signature(data, signature, publicKey);
 ```
 
-#### 6.2.6. SHA384withECDSA
+#### 6.2.6. [RSASSA-PSS-SHA256](#626-rsassa-pss-sha256)
+
+This API can be used to verify the RSASSA-PSS based signature.
+
+```ballerina
+string input = "Hello Ballerina";
+byte[] data = input.toBytes();
+crypto:KeyStore keyStore = {
+    path: "/path/to/keyStore.p12",
+    password: "keyStorePassword"
+};
+crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
+byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
+crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keyStore, "keyAlias");
+boolean validity = check crypto:verifyRsaSsaPss256Signature(data, signature, publicKey);
+```
+
+#### 6.2.7. [SHA384withECDSA](#627-sha384withecdsa)
 
 This API can be used to verify the SHA384withECDSA based signature.
 
@@ -890,7 +924,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha384withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.7. SHA256withECDSA
+#### 6.2.8. [SHA256withECDSA](#628-sha256withecdsa)
 
 This API can be used to verify the SHA256withECDSA based signature.
 
@@ -907,7 +941,7 @@ crypto:PublicKey publicKey = check crypto:decodeEcPublicKeyFromTrustStore(keySto
 boolean validity = check crypto:verifySha256withEcdsaSignature(data, signature, publicKey);
 ```
 
-#### 6.2.8. ML-DSA-65
+#### 6.2.9. [ML-DSA-65](#629-mldsa65)
 
 This API can be used to verify the ML-DSA-65 based signature.
 

--- a/native/src/main/java/io/ballerina/stdlib/crypto/nativeimpl/Sign.java
+++ b/native/src/main/java/io/ballerina/stdlib/crypto/nativeimpl/Sign.java
@@ -83,6 +83,12 @@ public class Sign {
         return CryptoUtils.sign("SHA512withRSA", key, input);
     }
 
+    public static Object signRsaSsaPss256(BArray inputValue, BMap<?, ?> privateKey) {
+        byte[] input = inputValue.getBytes();
+        PrivateKey key = (PrivateKey) privateKey.getNativeData(Constants.NATIVE_DATA_PRIVATE_KEY);
+        return CryptoUtils.sign("SHA256withRSAandMGF1", key, input);
+    }
+
     public static Object verifyMlDsa65Signature(BArray dataValue, BArray signatureValue,
                                                BMap<?, ?> publicKey) {
         byte[] data = dataValue.getBytes();
@@ -129,6 +135,14 @@ public class Sign {
         byte[] signature = signatureValue.getBytes();
         PublicKey key = (PublicKey) publicKey.getNativeData(Constants.NATIVE_DATA_PUBLIC_KEY);
         return CryptoUtils.verify("SHA512withRSA", key, data, signature);
+    }
+
+    public static Object verifyRsaSsaPss256Signature(BArray dataValue, BArray signatureValue,
+                                                     BMap<?, ?> publicKey) {
+        byte[] data = dataValue.getBytes();
+        byte[] signature = signatureValue.getBytes();
+        PublicKey key = (PublicKey) publicKey.getNativeData(Constants.NATIVE_DATA_PUBLIC_KEY);
+        return CryptoUtils.verify("SHA256withRSAandMGF1", key, data, signature);
     }
 
     public static Object verifySha384withEcdsaSignature(BArray dataValue, BArray signatureValue, BMap<?, ?> publicKey) {


### PR DESCRIPTION
## Purpose

Fixes [#8292](https://github.com/ballerina-platform/ballerina-library/issues/8292)

This PR implements RSASSA-PSS (PS256) signature support for the Ballerina crypto library, addressing the current limitation where only classic RSA signatures (PKCS#1 v1.5) are available.

## Examples

### Sign data
```ballerina
crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromKeyStore(keyStore, "keyAlias", "keyPassword");
byte[] signature = check crypto:signRsaSsaPss256(data, privateKey);
```
### Verify signature
```ballerina
crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromTrustStore(keyStore, "keyAlias");
boolean isValid = check crypto:verifyRsaSsaPss256Signature(data, signature, publicKey);
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
