### PR TITLE
Update CompilerPlugin.toml

### DIFF
--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "crypto-compiler-plugin"
 class = "io.ballerina.stdlib.crypto.compiler.CryptoCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.10.1.jar"
+path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.11.0-SNAPSHOT.jar"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -88,9 +88,9 @@ tasks.register('commitTomlFiles') {
         project.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"
+                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             } else {
-                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml"
+                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             }
         }
     }


### PR DESCRIPTION
## Purpose

Update CompilerPlugin.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates TOML configuration related to the compiler plugin and adjusts the automated TOML commit task.

## Changes

- **ballerina/CompilerPlugin.toml**: Updated the compiler plugin artifact reference from `crypto-compiler-plugin-2.10.1.jar` to `crypto-compiler-plugin-2.11.0-SNAPSHOT.jar` to point the build to the newer snapshot plugin version.
- **ballerina/build.gradle**: Extended the `commitTomlFiles` task to include `CompilerPlugin.toml` alongside `Ballerina.toml` and `Dependencies.toml` in the automated commit command for both Windows and non-Windows execution paths.

Lines changed: +1/-1 (CompilerPlugin.toml), +2/-2 (build.gradle)

Intent: update dependency handling to use the latest compiler plugin snapshot and ensure the automated TOML commit process includes the new file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->