### PR TITLE
Add configurable for-your-eyes-only option to encryptStreamAsPgp

### DIFF
--- a/ballerina/pgp_utils.bal
+++ b/ballerina/pgp_utils.bal
@@ -20,11 +20,13 @@
 # + symmetricKeyAlgorithm - Specifies the symmetric key algorithm used for encryption
 # + armor - Indicates whether ASCII armor is enabled for the encrypted output
 # + withIntegrityCheck - Indicates whether an integrity check is included in the encryption
+# + markForYourEyesOnly - Indicates whether the message is marked as "For Your Eyes Only". When `true`, the literal data packet filename is set to `_CONSOLE`, which signals PGP-compliant applications to treat the content as sensitive and avoid writing it to disk. Set to `false` to omit this marking
 public type Options record {|
     CompressionAlgorithmTags compressionAlgorithm = ZIP;
     SymmetricKeyAlgorithmTags symmetricKeyAlgorithm = AES_256;
     boolean armor = true;
     boolean withIntegrityCheck = true;
+    boolean markForYourEyesOnly = true;
 |};
 
 # Represents the compression algorithms available in PGP.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.11.0-SNAPSHOT
+version=2.12.0-SNAPSHOT
 checkstylePluginVersion=10.12.0
 bouncycastleVersion=1.80
 spotbugsPluginVersion=6.0.18

--- a/native/src/main/java/io/ballerina/stdlib/crypto/PgpEncryptionGenerator.java
+++ b/native/src/main/java/io/ballerina/stdlib/crypto/PgpEncryptionGenerator.java
@@ -74,15 +74,17 @@ public class PgpEncryptionGenerator {
     private final int symmetricKeyAlgorithm;
     private final boolean armor;
     private final boolean withIntegrityCheck;
+    private final boolean markForYourEyesOnly;
     public static final int BUFFER_SIZE = 8192;
 
     // The constructor of the PGP encryption generator.
     public PgpEncryptionGenerator(int compressionAlgorithm, int symmetricKeyAlgorithm, boolean armor,
-                                  boolean withIntegrityCheck) {
+                                  boolean withIntegrityCheck, boolean markForYourEyesOnly) {
         this.compressionAlgorithm = compressionAlgorithm;
         this.symmetricKeyAlgorithm = symmetricKeyAlgorithm;
         this.armor = armor;
         this.withIntegrityCheck = withIntegrityCheck;
+        this.markForYourEyesOnly = markForYourEyesOnly;
     }
 
     private void encryptStream(OutputStream encryptOut, InputStream clearIn, InputStream publicKeyIn)
@@ -103,7 +105,7 @@ public class PgpEncryptionGenerator {
         }
 
         try (OutputStream cipherOutStream = pgpEncryptedDataGenerator.open(encryptOut, new byte[BUFFER_SIZE])) {
-            copyAsLiteralData(compressedDataGenerator.open(cipherOutStream), clearIn);
+            copyAsLiteralData(compressedDataGenerator.open(cipherOutStream), clearIn, markForYourEyesOnly);
             compressedDataGenerator.close();
         }
         encryptOut.close();
@@ -137,7 +139,7 @@ public class PgpEncryptionGenerator {
         iteratorObj.addNativeData(DATA_STREAM, cipherOutStream);
         iteratorObj.addNativeData(COMPRESSED_DATA_STREAM, compressedOutStream);
         iteratorObj.addNativeData(COMPRESSED_DATA_GENERATOR, compressedDataGenerator);
-        copyAsLiteralData(compressedOutStream, iteratorObj);
+        copyAsLiteralData(compressedOutStream, iteratorObj, markForYourEyesOnly);
     }
 
     // Encrypts the given byte array of plain text data using PGP encryption.
@@ -163,11 +165,12 @@ public class PgpEncryptionGenerator {
         throw new PGPException("Invalid public key");
     }
 
-    private static void copyAsLiteralData(OutputStream outputStream, InputStream in)
+    private static void copyAsLiteralData(OutputStream outputStream, InputStream in, boolean markForYourEyesOnly)
             throws IOException {
         PGPLiteralDataGenerator lData = new PGPLiteralDataGenerator();
+        String fileName = markForYourEyesOnly ? PGPLiteralData.CONSOLE : "";
         byte[] buff = new byte[BUFFER_SIZE];
-        try (OutputStream pOut = lData.open(outputStream, PGPLiteralData.BINARY, PGPLiteralData.CONSOLE,
+        try (OutputStream pOut = lData.open(outputStream, PGPLiteralData.BINARY, fileName,
                 Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)), new byte[BUFFER_SIZE]);
              InputStream inputStream = in) {
 
@@ -180,10 +183,11 @@ public class PgpEncryptionGenerator {
         }
     }
 
-    private static void copyAsLiteralData(OutputStream outputStream, BObject iteratorObj)
+    private static void copyAsLiteralData(OutputStream outputStream, BObject iteratorObj, boolean markForYourEyesOnly)
             throws IOException {
         PGPLiteralDataGenerator lData = new PGPLiteralDataGenerator();
-        OutputStream pOut = lData.open(outputStream, PGPLiteralData.BINARY, PGPLiteralData.CONSOLE,
+        String fileName = markForYourEyesOnly ? PGPLiteralData.CONSOLE : "";
+        OutputStream pOut = lData.open(outputStream, PGPLiteralData.BINARY, fileName,
                 Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)), new byte[BUFFER_SIZE]);
         iteratorObj.addNativeData(TARGET_STREAM, pOut);
     }

--- a/native/src/main/java/io/ballerina/stdlib/crypto/nativeimpl/Encrypt.java
+++ b/native/src/main/java/io/ballerina/stdlib/crypto/nativeimpl/Encrypt.java
@@ -58,6 +58,7 @@ public class Encrypt {
     private static final BString SYMMETRIC_KEY_ALGORITHM = StringUtils.fromString("symmetricKeyAlgorithm");
     private static final BString ARMOR = StringUtils.fromString("armor");
     private static final BString WITH_INTEGRITY_CHECK = StringUtils.fromString("withIntegrityCheck");
+    private static final BString MARK_FOR_YOUR_EYES_ONLY = StringUtils.fromString("markForYourEyesOnly");
     public static final String ERROR_OCCURRED_WHILE_READING_PUBLIC_KEY = "Error occurred while reading public key: ";
     public static final String ERROR_OCCURRED_WHILE_PGP_ENCRYPT = "Error occurred while PGP encrypt: ";
 
@@ -122,7 +123,8 @@ public class Encrypt {
                     Integer.parseInt(options.get(COMPRESSION_ALGORITHM).toString()),
                     Integer.parseInt(options.get(SYMMETRIC_KEY_ALGORITHM).toString()),
                     Boolean.parseBoolean(options.get(ARMOR).toString()),
-                    Boolean.parseBoolean(options.get(WITH_INTEGRITY_CHECK).toString())
+                    Boolean.parseBoolean(options.get(WITH_INTEGRITY_CHECK).toString()),
+                    Boolean.parseBoolean(options.get(MARK_FOR_YOUR_EYES_ONLY).toString())
             );
             return pgpEncryptionGenerator.encrypt(plainText, publicKeyStream);
         } catch (IOException | PGPException e) {
@@ -145,7 +147,8 @@ public class Encrypt {
                     Integer.parseInt(options.get(COMPRESSION_ALGORITHM).toString()),
                     Integer.parseInt(options.get(SYMMETRIC_KEY_ALGORITHM).toString()),
                     Boolean.parseBoolean(options.get(ARMOR).toString()),
-                    Boolean.parseBoolean(options.get(WITH_INTEGRITY_CHECK).toString())
+                    Boolean.parseBoolean(options.get(WITH_INTEGRITY_CHECK).toString()),
+                    Boolean.parseBoolean(options.get(MARK_FOR_YOUR_EYES_ONLY).toString())
             );
             BObject iteratorObj = ValueCreator.createObjectValue(ModuleUtils.getModule(), "EncryptedStreamIterator");
             iteratorObj.addNativeData(END_OF_INPUT_STREAM, false);


### PR DESCRIPTION
## Description

This PR resolves: https://github.com/ballerina-platform/ballerina-lang/issues/44575

**Fix PGP "For Your Eyes Only" warning in `encryptStreamAsPgp` and `encryptPgp`**

The literal data packet filename was hardcoded to `_CONSOLE` in `PgpEncryptionGenerator.java`, which caused a `"for-your-eyes-only"` warning on decryption and broke some strict PGP clients.

**Changes**
- Added `markForYourEyesOnly` boolean option to the `Options` record (default `true` for backward compatibility)
- When `false`, the literal data packet filename is set to `""`, suppressing the FYEO marking

**Usage**
```ballerina
// No FYEO warning
stream<byte[], crypto:Error?> encryptedStream = check crypto:encryptStreamAsPgp(
    inputStream, "public_key.asc", markForYourEyesOnly = false);
```

You can confirm the fix with `gpg --list-packets` — it will show `name=""` instead of `name="_CONSOLE"`.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request introduces a configurable "for-your-eyes-only" option to the PGP encryption functionality in the Ballerina crypto module. The feature allows users to optionally mark encrypted content with a specific indicator to signal sensitive handling.

### Changes Made

- **API Enhancement**: Added a new `isForYourEyesOnly` boolean field (defaulting to `false`) to the `Options` public record in the PGP utilities module, allowing callers to configure this behavior.

- **Implementation**: Updated the PGP encryption generator to conditionally set the literal data packet filename based on the new flag. When enabled, the filename is set to a console indicator; when disabled, an empty string is used.

- **Plumbing**: Extended both encryption entry points (`encryptPgp` and `encryptStreamAsPgp`) to parse and pass the new configuration option through to the underlying encryption implementation.

- **Version Bump**: Updated the project version from `2.11.0-SNAPSHOT` to `2.12.0-SNAPSHOT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->