### PR TITLE
Update spec and changelog for `markForYourEyesOnly` PGP option

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "crypto"
-version = "2.11.0"
+version = "2.12.0"
 authors = ["Ballerina"]
 keywords = ["security", "hash", "hmac", "sign", "encrypt", "decrypt", "private key", "public key"]
 repository = "https://github.com/ballerina-platform/module-ballerina-crypto"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "crypto-native"
-version = "2.11.0"
-path = "../native/build/libs/crypto-native-2.11.0-SNAPSHOT.jar"
+version = "2.12.0"
+path = "../native/build/libs/crypto-native-2.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.bouncycastle"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "crypto-compiler-plugin"
 class = "io.ballerina.stdlib.crypto.compiler.CryptoCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.11.0-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.12.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Add `markForYourEyesOnly` option to `Options` record to control PGP literal data packet "For Your Eyes Only" marking in `encryptPgp` and `encryptStreamAsPgp`](https://github.com/ballerina-platform/ballerina-lang/issues/44575)
+
+## [2.11.0] - 2026-04-07
+
+### Added
 - [Introduce `equalConstantTime` API for timing-safe comparison of byte arrays and strings](https://github.com/ballerina-platform/ballerina-library/issues/8733)
 
 ## [2.10.0] - 2025-12-10

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -552,6 +552,7 @@ The following encryption options can be configured in the PGP encryption.
 | symmetricKeyAlgorithm | Specifies the symmetric key algorithm used for encryption         | AES_256       |
 | armor                 | Indicates whether ASCII armor is enabled for the encrypted output | true          |
 | withIntegrityCheck    | Indicates whether integrity check is included in the encryption   | true          |
+| markForYourEyesOnly   | When `true`, sets the literal data packet filename to `_CONSOLE`, marking the message as "For Your Eyes Only" per RFC 4880 §5.9. Set to `false` to use an empty filename and suppress the FYEO marking | true          |
 
 ```ballerina
 string input = "Hello Ballerina";


### PR DESCRIPTION
## Purpose
$Subject

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the crypto module to version 2.12.0 and introduces a new PGP encryption configuration option to enhance the flexibility of the encryption functionality.

## Changes

**Version and Dependencies:** Updated module version from 2.11.0 to 2.12.0 across all manifest files (Ballerina.toml, CompilerPlugin.toml, and Dependencies.toml), along with corresponding native JAR dependency updates.

**New Feature:** Introduced `markForYourEyesOnly` option in the PGP encryption Options record, allowing callers to control the "For Your Eyes Only" marking behavior of the PGP literal data packet. When enabled (default), it sets the packet filename to `_CONSOLE`; when disabled, it uses an empty filename to suppress the marking.

**Documentation:** Updated the specification and changelog to document the new `markForYourEyesOnly` configuration option for the PGP encryption functions `encryptPgp` and `encryptStreamAsPgp`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->