### PR TITLE
Fix backward compatibility of PgpEncryptionGenerator constructor

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/crypto/PgpEncryptionGenerator.java
+++ b/native/src/main/java/io/ballerina/stdlib/crypto/PgpEncryptionGenerator.java
@@ -79,6 +79,15 @@ public class PgpEncryptionGenerator {
 
     // The constructor of the PGP encryption generator.
     public PgpEncryptionGenerator(int compressionAlgorithm, int symmetricKeyAlgorithm, boolean armor,
+                                  boolean withIntegrityCheck) {
+        this.compressionAlgorithm = compressionAlgorithm;
+        this.symmetricKeyAlgorithm = symmetricKeyAlgorithm;
+        this.armor = armor;
+        this.withIntegrityCheck = withIntegrityCheck;
+        this.markForYourEyesOnly = true;
+    }
+
+    public PgpEncryptionGenerator(int compressionAlgorithm, int symmetricKeyAlgorithm, boolean armor,
                                   boolean withIntegrityCheck, boolean markForYourEyesOnly) {
         this.compressionAlgorithm = compressionAlgorithm;
         this.symmetricKeyAlgorithm = symmetricKeyAlgorithm;


### PR DESCRIPTION
## Purpose
$Subject

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Restored backward compatibility for the `PgpEncryptionGenerator` constructor by introducing a constructor overload that accepts four parameters instead of five.

## Changes
Added a new constructor overload to `PgpEncryptionGenerator` that accepts only the compression algorithm, symmetric key algorithm, armor flag, and integrity-check flag. This overload defaults the `markForYourEyesOnly` flag to `true`, eliminating the need to explicitly provide this parameter for standard use cases. The existing 5-parameter constructor is retained to support scenarios requiring explicit control over all configuration options.

## Impact
This change enables backward compatibility by supporting both constructor signatures, allowing existing code that relies on the 4-parameter constructor to continue functioning while preserving the flexibility of the 5-parameter variant for advanced use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->