### PR TITLE
Add six static code analysis rules for crypto

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "crypto"
-version = "2.12.1"
+version = "2.12.2"
 authors = ["Ballerina"]
 keywords = ["security", "hash", "hmac", "sign", "encrypt", "decrypt", "private key", "public key"]
 repository = "https://github.com/ballerina-platform/module-ballerina-crypto"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "crypto-native"
-version = "2.12.1"
-path = "../native/build/libs/crypto-native-2.12.1.jar"
+version = "2.12.2"
+path = "../native/build/libs/crypto-native-2.12.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.bouncycastle"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "crypto-compiler-plugin"
 class = "io.ballerina.stdlib.crypto.compiler.CryptoCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.12.1.jar"
+path = "../compiler-plugin/build/libs/crypto-compiler-plugin-2.12.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -49,6 +49,12 @@ import java.util.stream.Collectors;
 import static io.ballerina.scan.RuleKind.VULNERABILITY;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_FAST_HASH_ALGORITHMS;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_REUSING_COUNTER_MODE_VECTORS;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_HARDCODED_KEY_MATERIAL;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_PGP_ALGORITHMS;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.ENSURE_PGP_INTEGRITY_CHECK;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_SHORT_AUTHENTICATION_TAGS;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.ENSURE_SIGNATURE_VERIFICATION;
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_HASH_ALGORITHMS;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_CIPHER_ALGORITHMS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -116,6 +122,36 @@ public class StaticCodeAnalyzerTest {
                 rules,
                 "ballerina/crypto:3",
                 AVOID_REUSING_COUNTER_MODE_VECTORS.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:4",
+                AVOID_WEAK_HASH_ALGORITHMS.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:5",
+                AVOID_HARDCODED_KEY_MATERIAL.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:6",
+                AVOID_WEAK_PGP_ALGORITHMS.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:7",
+                ENSURE_PGP_INTEGRITY_CHECK.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:8",
+                AVOID_SHORT_AUTHENTICATION_TAGS.getDescription(),
+                VULNERABILITY);
+        Assertions.assertRule(
+                rules,
+                "ballerina/crypto:9",
+                ENSURE_SIGNATURE_VERIFICATION.getDescription(),
                 VULNERABILITY);
     }
 
@@ -236,6 +272,70 @@ public class StaticCodeAnalyzerTest {
                 Assertions.assertIssue(issues, index++, "ballerina/crypto:3", "mod_var_named_arg.bal",
                         23, 23, Source.BUILT_IN);
                 Assertions.assertIssue(issues, index, "ballerina/crypto:3", "mod_var_pos_arg.bal",
+                        23, 23, Source.BUILT_IN);
+                break;
+            case AVOID_WEAK_HASH_ALGORITHMS:
+                index = 0;
+                Assert.assertEquals(issues.size(), 8);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_hash.bal",
+                        19, 19, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_hash.bal",
+                        20, 20, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_hash.bal",
+                        24, 24, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_hash.bal",
+                        25, 25, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_signature.bal",
+                        19, 19, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_signature.bal",
+                        20, 20, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:4", "weak_signature.bal",
+                        24, 24, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:4", "weak_signature.bal",
+                        25, 25, Source.BUILT_IN);
+                break;
+            case AVOID_HARDCODED_KEY_MATERIAL:
+                index = 0;
+                Assert.assertEquals(issues.size(), 3);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:5", "hardcoded_key.bal",
+                        21, 21, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:5", "hardcoded_key.bal",
+                        25, 25, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:5", "hardcoded_key.bal",
+                        29, 29, Source.BUILT_IN);
+                break;
+            case AVOID_WEAK_PGP_ALGORITHMS:
+                index = 0;
+                Assert.assertEquals(issues.size(), 3);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:6", "weak_pgp_algorithm.bal",
+                        19, 19, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:6", "weak_pgp_algorithm.bal",
+                        23, 23, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:6", "weak_pgp_algorithm.bal",
+                        27, 27, Source.BUILT_IN);
+                break;
+            case ENSURE_PGP_INTEGRITY_CHECK:
+                index = 0;
+                Assert.assertEquals(issues.size(), 1);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:7", "pgp_integrity.bal",
+                        19, 19, Source.BUILT_IN);
+                break;
+            case AVOID_SHORT_AUTHENTICATION_TAGS:
+                index = 0;
+                Assert.assertEquals(issues.size(), 3);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:8", "short_tag.bal",
+                        21, 21, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:8", "short_tag.bal",
+                        25, 25, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:8", "short_tag.bal",
+                        29, 29, Source.BUILT_IN);
+                break;
+            case ENSURE_SIGNATURE_VERIFICATION:
+                index = 0;
+                Assert.assertEquals(issues.size(), 2);
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:9", "discarded_verification.bal",
+                        19, 19, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:9", "discarded_verification.bal",
                         23, 23, Source.BUILT_IN);
                 break;
             default:

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -322,13 +322,15 @@ public class StaticCodeAnalyzerTest {
                 break;
             case AVOID_SHORT_AUTHENTICATION_TAGS:
                 index = 0;
-                Assert.assertEquals(issues.size(), 3);
+                Assert.assertEquals(issues.size(), 4);
                 Assertions.assertIssue(issues, index++, "ballerina/crypto:8", "short_tag.bal",
                         21, 21, Source.BUILT_IN);
                 Assertions.assertIssue(issues, index++, "ballerina/crypto:8", "short_tag.bal",
                         25, 25, Source.BUILT_IN);
-                Assertions.assertIssue(issues, index, "ballerina/crypto:8", "short_tag.bal",
+                Assertions.assertIssue(issues, index++, "ballerina/crypto:8", "short_tag.bal",
                         29, 29, Source.BUILT_IN);
+                Assertions.assertIssue(issues, index, "ballerina/crypto:8", "short_tag.bal",
+                        33, 33, Source.BUILT_IN);
                 break;
             case ENSURE_SIGNATURE_VERIFICATION:
                 index = 0;

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/StaticCodeAnalyzerTest.java
@@ -376,7 +376,7 @@ public class StaticCodeAnalyzerTest {
             ObjectMapper mapper = new ObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
             JsonNode node = mapper.readTree(json);
             String normalizedJson = mapper.writeValueAsString(node)
-                    .replaceAll(":\".*" + MODULE_BALLERINA_CRYPTO, ":\"" + MODULE_BALLERINA_CRYPTO);
+                    .replaceAll(":\"[^\"]*" + MODULE_BALLERINA_CRYPTO, ":\"" + MODULE_BALLERINA_CRYPTO);
             return isWindows() ? normalizedJson.replace("/", "\\\\") : normalizedJson;
         } catch (Exception ignore) {
             return json;

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule4"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+function weakHashes(string data) {
+    byte[] _ = crypto:hashMd5(data.toBytes());
+    byte[] _ = crypto:hashSha1(data.toBytes());
+}
+
+function weakHmacs(string data, byte[] key) {
+    byte[] _ = crypto:hmacMd5(data.toBytes(), key);
+    byte[] _ = crypto:hmacSha1(data.toBytes(), key);
+}
+
+// Negative cases - these algorithms are not flagged
+function strongHashes(string data, byte[] key) {
+    byte[] _ = crypto:hashSha256(data.toBytes());
+    byte[] _ = crypto:hashSha512(data.toBytes());
+    byte[] _ = crypto:hmacSha256(data.toBytes(), key);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+function weakSignatures(byte[] data, crypto:PrivateKey privateKey) returns error? {
+    byte[] _ = check crypto:signRsaMd5(data, privateKey);
+    byte[] _ = check crypto:signRsaSha1(data, privateKey);
+}
+
+function weakVerification(byte[] data, byte[] signature, crypto:PublicKey publicKey) returns error? {
+    boolean md5Valid = check crypto:verifyRsaMd5Signature(data, signature, publicKey);
+    boolean sha1Valid = check crypto:verifyRsaSha1Signature(data, signature, publicKey);
+    if !md5Valid || !sha1Valid {
+        return error("signature verification failed");
+    }
+}
+
+// Negative case - SHA-256 signatures are not flagged
+function strongSignature(byte[] data, crypto:PrivateKey privateKey) returns error? {
+    byte[] _ = check crypto:signRsaSha256(data, privateKey);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule5"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/hardcoded_key.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/hardcoded_key.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+configurable byte[] configuredKey = ?;
+
+function hardcodedHmacKey(string data) returns error? {
+    byte[] _ = check crypto:hmacSha256(data.toBytes(), [1, 2, 3, 4, 5, 6, 7, 8]);
+}
+
+function hardcodedAesKey(string data, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data.toBytes(), [9, 9, 9, 9, 9, 9, 9, 9], iv);
+}
+
+function hardcodedPassphrase(byte[] cipherText, string privateKeyPath) returns error? {
+    byte[] _ = check crypto:decryptPgp(cipherText, privateKeyPath, "my-passphrase".toBytes());
+}
+
+// Negative case - key material supplied at deployment is the correct usage
+function configuredHmacKey(string data) returns error? {
+    byte[] _ = check crypto:hmacSha256(data.toBytes(), configuredKey);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule6"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/weak_pgp_algorithm.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/weak_pgp_algorithm.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+function weakPgpAlgorithm(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, symmetricKeyAlgorithm = crypto:DES);
+}
+
+function noPgpEncryption(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, symmetricKeyAlgorithm = crypto:NULL);
+}
+
+function tripleDesPgp(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, symmetricKeyAlgorithm = crypto:TRIPLE_DES);
+}
+
+// Negative case - AES-256 is the default and is not flagged
+function strongPgpAlgorithm(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, symmetricKeyAlgorithm = crypto:AES_256);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule7/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule7/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule7"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule7/pgp_integrity.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule7/pgp_integrity.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+function integrityCheckDisabled(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, withIntegrityCheck = false);
+}
+
+// Negative case - integrity protection is on by default
+function integrityCheckEnabled(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath, withIntegrityCheck = true);
+}
+
+function integrityCheckDefault(byte[] data, string publicKeyPath) returns error? {
+    byte[] _ = check crypto:encryptPgp(data, publicKeyPath);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule8"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal
@@ -30,6 +30,10 @@ function shortTagOnDecrypt(byte[] data, byte[] key, byte[] iv) returns error? {
     byte[] _ = check crypto:decryptAesGcm(data, key, iv, tagSize = 32);
 }
 
+function shortTagHexLiteral(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data, key, iv, tagSize = 0x20);
+}
+
 // Negative cases - the documented minimum and the default are not flagged
 function documentedMinimumTag(byte[] data, byte[] key, byte[] iv) returns error? {
     byte[] _ = check crypto:encryptAesGcm(data, key, iv, tagSize = 96);

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+const int SHORT_TAG = 32;
+
+function shortTagInline(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data, key, iv, tagSize = 64);
+}
+
+function shortTagConstant(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data, key, iv, tagSize = SHORT_TAG);
+}
+
+function shortTagOnDecrypt(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:decryptAesGcm(data, key, iv, tagSize = 32);
+}
+
+// Negative cases - the documented minimum and the default are not flagged
+function documentedMinimumTag(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data, key, iv, tagSize = 96);
+}
+
+function defaultTag(byte[] data, byte[] key, byte[] iv) returns error? {
+    byte[] _ = check crypto:encryptAesGcm(data, key, iv);
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "wso2"
+name = "rule9"
+version = "0.1.0"
+distribution = "2201.12.3"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com)
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/crypto;
+
+function discardedInDeclaration(byte[] data, byte[] signature, crypto:PublicKey publicKey) returns error? {
+    boolean _ = check crypto:verifyRsaSha256Signature(data, signature, publicKey);
+}
+
+function discardedInAssignment(byte[] data, byte[] signature, crypto:PublicKey publicKey) returns error? {
+    _ = check crypto:verifyRsaSha512Signature(data, signature, publicKey);
+}
+
+// Negative case - the result is bound and acted on
+function verificationChecked(byte[] data, byte[] signature, crypto:PublicKey publicKey) returns error? {
+    boolean valid = check crypto:verifyRsaSha256Signature(data, signature, publicKey);
+    if !valid {
+        return error("signature verification failed");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal
@@ -31,3 +31,16 @@ function verificationChecked(byte[] data, byte[] signature, crypto:PublicKey pub
         return error("signature verification failed");
     }
 }
+
+// Negative case - the result is handed to another call that acts on it, even though that call's own result is
+// discarded
+function verificationPassedOn(byte[] data, byte[] signature, crypto:PublicKey publicKey) returns error? {
+    boolean _ = check requireValid(check crypto:verifyRsaSha256Signature(data, signature, publicKey));
+}
+
+function requireValid(boolean valid) returns boolean|error {
+    if !valid {
+        return error("signature verification failed");
+    }
+    return valid;
+}

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule3.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule3.json
@@ -242,6 +242,26 @@
   {
     "location": {
       "filePath": "func_hardcoded_iv_param.bal",
+      "startLine": 36,
+      "endLine": 36,
+      "startColumn": 14,
+      "endColumn": 54,
+      "startOffset": 1427,
+      "length": 40
+    },
+    "rule": {
+      "id": "ballerina/crypto:3",
+      "numericId": 3,
+      "description": "Avoid reusing counter mode initialization vectors",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule3/func_hardcoded_iv_param.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule3/func_hardcoded_iv_param.bal"
+  },
+  {
+    "location": {
+      "filePath": "func_hardcoded_iv_param.bal",
       "startLine": 39,
       "endLine": 39,
       "startColumn": 14,

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule4.json
@@ -1,0 +1,162 @@
+[
+  {
+    "location": {
+      "filePath": "weak_hash.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 15,
+      "endColumn": 45,
+      "startOffset": 719,
+      "length": 30
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_hash.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_hash.bal",
+      "startLine": 20,
+      "endLine": 20,
+      "startColumn": 15,
+      "endColumn": 46,
+      "startOffset": 766,
+      "length": 31
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_hash.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_hash.bal",
+      "startLine": 24,
+      "endLine": 24,
+      "startColumn": 15,
+      "endColumn": 50,
+      "startOffset": 863,
+      "length": 35
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_hash.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_hash.bal",
+      "startLine": 25,
+      "endLine": 25,
+      "startColumn": 15,
+      "endColumn": 51,
+      "startOffset": 915,
+      "length": 36
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_hash.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_hash.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_signature.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 21,
+      "endColumn": 56,
+      "startOffset": 774,
+      "length": 35
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_signature.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_signature.bal",
+      "startLine": 20,
+      "endLine": 20,
+      "startColumn": 21,
+      "endColumn": 57,
+      "startOffset": 832,
+      "length": 36
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_signature.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_signature.bal",
+      "startLine": 24,
+      "endLine": 24,
+      "startColumn": 29,
+      "endColumn": 85,
+      "startOffset": 1004,
+      "length": 56
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_signature.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_signature.bal",
+      "startLine": 25,
+      "endLine": 25,
+      "startColumn": 30,
+      "endColumn": 87,
+      "startOffset": 1092,
+      "length": 57
+    },
+    "rule": {
+      "id": "ballerina/crypto:4",
+      "numericId": 4,
+      "description": "Avoid using weak hashing and signature algorithms",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule4/weak_signature.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule4/weak_signature.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule5.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule5.json
@@ -1,0 +1,62 @@
+[
+  {
+    "location": {
+      "filePath": "hardcoded_key.bal",
+      "startLine": 21,
+      "endLine": 21,
+      "startColumn": 21,
+      "endColumn": 80,
+      "startOffset": 786,
+      "length": 59
+    },
+    "rule": {
+      "id": "ballerina/crypto:5",
+      "numericId": 5,
+      "description": "Avoid hard-coded key material",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule5/hardcoded_key.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/hardcoded_key.bal"
+  },
+  {
+    "location": {
+      "filePath": "hardcoded_key.bal",
+      "startLine": 25,
+      "endLine": 25,
+      "startColumn": 21,
+      "endColumn": 87,
+      "startOffset": 937,
+      "length": 66
+    },
+    "rule": {
+      "id": "ballerina/crypto:5",
+      "numericId": 5,
+      "description": "Avoid hard-coded key material",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule5/hardcoded_key.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/hardcoded_key.bal"
+  },
+  {
+    "location": {
+      "filePath": "hardcoded_key.bal",
+      "startLine": 29,
+      "endLine": 29,
+      "startColumn": 21,
+      "endColumn": 93,
+      "startOffset": 1117,
+      "length": 72
+    },
+    "rule": {
+      "id": "ballerina/crypto:5",
+      "numericId": 5,
+      "description": "Avoid hard-coded key material",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule5/hardcoded_key.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule5/hardcoded_key.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule6.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule6.json
@@ -1,0 +1,62 @@
+[
+  {
+    "location": {
+      "filePath": "weak_pgp_algorithm.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 21,
+      "endColumn": 95,
+      "startOffset": 768,
+      "length": 74
+    },
+    "rule": {
+      "id": "ballerina/crypto:6",
+      "numericId": 6,
+      "description": "Avoid using weak symmetric algorithms for PGP encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule6/weak_pgp_algorithm.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/weak_pgp_algorithm.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_pgp_algorithm.bal",
+      "startLine": 23,
+      "endLine": 23,
+      "startColumn": 21,
+      "endColumn": 96,
+      "startOffset": 945,
+      "length": 75
+    },
+    "rule": {
+      "id": "ballerina/crypto:6",
+      "numericId": 6,
+      "description": "Avoid using weak symmetric algorithms for PGP encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule6/weak_pgp_algorithm.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/weak_pgp_algorithm.bal"
+  },
+  {
+    "location": {
+      "filePath": "weak_pgp_algorithm.bal",
+      "startLine": 27,
+      "endLine": 27,
+      "startColumn": 21,
+      "endColumn": 102,
+      "startOffset": 1120,
+      "length": 81
+    },
+    "rule": {
+      "id": "ballerina/crypto:6",
+      "numericId": 6,
+      "description": "Avoid using weak symmetric algorithms for PGP encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule6/weak_pgp_algorithm.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule6/weak_pgp_algorithm.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule7.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule7.json
@@ -1,0 +1,22 @@
+[
+  {
+    "location": {
+      "filePath": "pgp_integrity.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 21,
+      "endColumn": 87,
+      "startOffset": 774,
+      "length": 66
+    },
+    "rule": {
+      "id": "ballerina/crypto:7",
+      "numericId": 7,
+      "description": "Avoid disabling integrity protection for PGP encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule7/pgp_integrity.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule7/pgp_integrity.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule8.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule8.json
@@ -58,5 +58,25 @@
     "source": "BUILT_IN",
     "fileName": "rule8/short_tag.bal",
     "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal"
+  },
+  {
+    "location": {
+      "filePath": "short_tag.bal",
+      "startLine": 33,
+      "endLine": 33,
+      "startColumn": 21,
+      "endColumn": 72,
+      "startOffset": 1266,
+      "length": 51
+    },
+    "rule": {
+      "id": "ballerina/crypto:8",
+      "numericId": 8,
+      "description": "Avoid using short authentication tags for counter mode encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule8/short_tag.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal"
   }
 ]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule8.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule8.json
@@ -1,0 +1,62 @@
+[
+  {
+    "location": {
+      "filePath": "short_tag.bal",
+      "startLine": 21,
+      "endLine": 21,
+      "startColumn": 21,
+      "endColumn": 70,
+      "startOffset": 794,
+      "length": 49
+    },
+    "rule": {
+      "id": "ballerina/crypto:8",
+      "numericId": 8,
+      "description": "Avoid using short authentication tags for counter mode encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule8/short_tag.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal"
+  },
+  {
+    "location": {
+      "filePath": "short_tag.bal",
+      "startLine": 25,
+      "endLine": 25,
+      "startColumn": 21,
+      "endColumn": 77,
+      "startOffset": 948,
+      "length": 56
+    },
+    "rule": {
+      "id": "ballerina/crypto:8",
+      "numericId": 8,
+      "description": "Avoid using short authentication tags for counter mode encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule8/short_tag.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal"
+  },
+  {
+    "location": {
+      "filePath": "short_tag.bal",
+      "startLine": 29,
+      "endLine": 29,
+      "startColumn": 21,
+      "endColumn": 70,
+      "startOffset": 1110,
+      "length": 49
+    },
+    "rule": {
+      "id": "ballerina/crypto:8",
+      "numericId": 8,
+      "description": "Avoid using short authentication tags for counter mode encryption",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule8/short_tag.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule8/short_tag.bal"
+  }
+]

--- a/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule9.json
+++ b/compiler-plugin-tests/src/test/resources/static_code_analyzer/expected_output/rule9.json
@@ -1,0 +1,42 @@
+[
+  {
+    "location": {
+      "filePath": "discarded_verification.bal",
+      "startLine": 19,
+      "endLine": 19,
+      "startColumn": 22,
+      "endColumn": 81,
+      "startOffset": 799,
+      "length": 59
+    },
+    "rule": {
+      "id": "ballerina/crypto:9",
+      "numericId": 9,
+      "description": "Avoid discarding the result of a signature verification",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule9/discarded_verification.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal"
+  },
+  {
+    "location": {
+      "filePath": "discarded_verification.bal",
+      "startLine": 23,
+      "endLine": 23,
+      "startColumn": 14,
+      "endColumn": 73,
+      "startOffset": 984,
+      "length": 59
+    },
+    "rule": {
+      "id": "ballerina/crypto:9",
+      "numericId": 9,
+      "description": "Avoid discarding the result of a signature verification",
+      "ruleKind": "VULNERABILITY"
+    },
+    "source": "BUILT_IN",
+    "fileName": "rule9/discarded_verification.bal",
+    "filePath": "module-ballerina-crypto/compiler-plugin-tests/src/test/resources/static_code_analyzer/ballerina_packages/rule9/discarded_verification.bal"
+  }
+]

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoAnalyzerUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoAnalyzerUtils.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.values.ConstantValue;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
@@ -270,11 +269,12 @@ public final class CryptoAnalyzerUtils {
     }
 
     /**
-     * Check whether the given expression is a byte array literal written directly at this position.
+     * Check whether the given expression is a byte array literal written directly at this position: a list
+     * constructor of numeric literals, or {@code toBytes()} called on a string literal.
      * <p>
-     * Unlike {@link #isHardCodedByteArray}, this does not follow a variable back to its initialiser. A variable
-     * initialised with a literal may be overwritten before use - filling a key array with random bytes in a loop is
-     * a common and correct pattern - so resolving through variables would report code that is not hard-coded at all.
+     * A variable is deliberately not followed back to its initialiser. One initialised with a literal may be
+     * overwritten before use - filling a key array with random bytes in a loop is a common and correct pattern - so
+     * resolving through variables would report code that is not hard-coded at all.
      *
      * @param expression the expression to check
      * @return true if the expression is itself a compile-time constant byte array
@@ -288,61 +288,6 @@ public final class CryptoAnalyzerUtils {
                 && methodCallExpression.expression().kind().equals(SyntaxKind.STRING_LITERAL)
                 && methodCallExpression.methodName() instanceof SimpleNameReferenceNode simpleNameRef) {
             return simpleNameRef.name().text().equals(TO_BYTES_METHOD);
-        }
-        return false;
-    }
-
-    /**
-     * Check whether the given expression is a hard-coded byte array.
-     * <p>
-     * Recognises a list constructor of numeric literals, and {@code toBytes()} called on a string literal or on a
-     * constant. A value that cannot be resolved at compile time is not hard-coded as far as this check is concerned.
-     *
-     * @param expression the expression to check
-     * @param context    the function context, used to resolve variables to their assigned expressions
-     * @return true if the expression resolves to a compile-time constant byte array
-     */
-    public static boolean isHardCodedByteArray(ExpressionNode expression, FunctionContext context) {
-        if (expression instanceof ListConstructorExpressionNode listExpression) {
-            return !listExpression.expressions().isEmpty() && listExpression.expressions().stream()
-                    .allMatch(expr -> expr.kind().equals(SyntaxKind.NUMERIC_LITERAL));
-        }
-
-        if (expression instanceof MethodCallExpressionNode methodCallExpression) {
-            if (!isConstantExpression(methodCallExpression.expression(), context)) {
-                return false;
-            }
-            NameReferenceNode nameReferenceNode = methodCallExpression.methodName();
-            if (nameReferenceNode instanceof SimpleNameReferenceNode simpleNameRef) {
-                return simpleNameRef.name().text().equals(TO_BYTES_METHOD);
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Check whether the given expression resolves to a compile-time constant.
-     *
-     * @param expression the expression to check
-     * @param context    the function context
-     * @return true if the expression is a string literal, a constant, or a variable holding either
-     */
-    public static boolean isConstantExpression(ExpressionNode expression, FunctionContext context) {
-        if (expression.kind().equals(SyntaxKind.STRING_LITERAL)) {
-            return true;
-        }
-        if (expression.kind().equals(SyntaxKind.SIMPLE_NAME_REFERENCE) ||
-                expression.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
-            Optional<Symbol> symbol = context.semanticModel().symbol(expression);
-            if (symbol.isPresent() && symbol.get().kind().equals(SymbolKind.CONSTANT)) {
-                return true;
-            }
-        }
-        if (expression instanceof SimpleNameReferenceNode simpleNameRef) {
-            String varName = unescapeIdentifier(simpleNameRef.name().text());
-            Optional<ExpressionNode> varExpression = context.getVarExpression(varName);
-            return varExpression.isPresent() && isConstantExpression(varExpression.get(), context);
         }
         return false;
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoAnalyzerUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoAnalyzerUtils.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.values.ConstantValue;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
@@ -34,6 +35,8 @@ import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
@@ -64,6 +67,7 @@ import java.util.Optional;
 public final class CryptoAnalyzerUtils {
     private static final String BALLERINA_ORG = "ballerina";
     private static final String CRYPTO = "crypto";
+    private static final String TO_BYTES_METHOD = "toBytes";
 
     // Private constructor to prevent instantiation
     private CryptoAnalyzerUtils() {
@@ -263,6 +267,84 @@ public final class CryptoAnalyzerUtils {
                 || kind.equals(SyntaxKind.LOCK_STATEMENT) || kind.equals(SyntaxKind.MATCH_STATEMENT)
                 || kind.equals(SyntaxKind.FOREACH_STATEMENT) || kind.equals(SyntaxKind.WHILE_STATEMENT)
                 || kind.equals(SyntaxKind.TRANSACTION_STATEMENT) || kind.equals(SyntaxKind.RETRY_STATEMENT);
+    }
+
+    /**
+     * Check whether the given expression is a byte array literal written directly at this position.
+     * <p>
+     * Unlike {@link #isHardCodedByteArray}, this does not follow a variable back to its initialiser. A variable
+     * initialised with a literal may be overwritten before use - filling a key array with random bytes in a loop is
+     * a common and correct pattern - so resolving through variables would report code that is not hard-coded at all.
+     *
+     * @param expression the expression to check
+     * @return true if the expression is itself a compile-time constant byte array
+     */
+    public static boolean isByteArrayLiteral(ExpressionNode expression) {
+        if (expression instanceof ListConstructorExpressionNode listExpression) {
+            return !listExpression.expressions().isEmpty() && listExpression.expressions().stream()
+                    .allMatch(expr -> expr.kind().equals(SyntaxKind.NUMERIC_LITERAL));
+        }
+        if (expression instanceof MethodCallExpressionNode methodCallExpression
+                && methodCallExpression.expression().kind().equals(SyntaxKind.STRING_LITERAL)
+                && methodCallExpression.methodName() instanceof SimpleNameReferenceNode simpleNameRef) {
+            return simpleNameRef.name().text().equals(TO_BYTES_METHOD);
+        }
+        return false;
+    }
+
+    /**
+     * Check whether the given expression is a hard-coded byte array.
+     * <p>
+     * Recognises a list constructor of numeric literals, and {@code toBytes()} called on a string literal or on a
+     * constant. A value that cannot be resolved at compile time is not hard-coded as far as this check is concerned.
+     *
+     * @param expression the expression to check
+     * @param context    the function context, used to resolve variables to their assigned expressions
+     * @return true if the expression resolves to a compile-time constant byte array
+     */
+    public static boolean isHardCodedByteArray(ExpressionNode expression, FunctionContext context) {
+        if (expression instanceof ListConstructorExpressionNode listExpression) {
+            return !listExpression.expressions().isEmpty() && listExpression.expressions().stream()
+                    .allMatch(expr -> expr.kind().equals(SyntaxKind.NUMERIC_LITERAL));
+        }
+
+        if (expression instanceof MethodCallExpressionNode methodCallExpression) {
+            if (!isConstantExpression(methodCallExpression.expression(), context)) {
+                return false;
+            }
+            NameReferenceNode nameReferenceNode = methodCallExpression.methodName();
+            if (nameReferenceNode instanceof SimpleNameReferenceNode simpleNameRef) {
+                return simpleNameRef.name().text().equals(TO_BYTES_METHOD);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether the given expression resolves to a compile-time constant.
+     *
+     * @param expression the expression to check
+     * @param context    the function context
+     * @return true if the expression is a string literal, a constant, or a variable holding either
+     */
+    public static boolean isConstantExpression(ExpressionNode expression, FunctionContext context) {
+        if (expression.kind().equals(SyntaxKind.STRING_LITERAL)) {
+            return true;
+        }
+        if (expression.kind().equals(SyntaxKind.SIMPLE_NAME_REFERENCE) ||
+                expression.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            Optional<Symbol> symbol = context.semanticModel().symbol(expression);
+            if (symbol.isPresent() && symbol.get().kind().equals(SymbolKind.CONSTANT)) {
+                return true;
+            }
+        }
+        if (expression instanceof SimpleNameReferenceNode simpleNameRef) {
+            String varName = unescapeIdentifier(simpleNameRef.name().text());
+            Optional<ExpressionNode> varExpression = context.getVarExpression(varName);
+            return varExpression.isPresent() && isConstantExpression(varExpression.get(), context);
+        }
+        return false;
     }
 
     /**

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoFunctionRulesEngine.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoFunctionRulesEngine.java
@@ -18,9 +18,15 @@
 package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 
 import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidFastHashAlgorithmsRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidHardcodedKeyMaterialRule;
 import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidReusingCounterModeVectorsRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidShortAuthenticationTagsRule;
 import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidWeakCipherAlgorithmsRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidWeakHashAlgorithmsRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.AvoidWeakPgpAlgorithmsRule;
 import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.CryptoFunctionRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.EnsurePgpIntegrityCheckRule;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules.EnsureSignatureVerificationRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +63,12 @@ public class CryptoFunctionRulesEngine {
         addRule(new AvoidWeakCipherAlgorithmsRule());
         addRule(new AvoidFastHashAlgorithmsRule());
         addRule(new AvoidReusingCounterModeVectorsRule());
+        addRule(new AvoidWeakHashAlgorithmsRule());
+        addRule(new AvoidHardcodedKeyMaterialRule());
+        addRule(new AvoidWeakPgpAlgorithmsRule());
+        addRule(new EnsurePgpIntegrityCheckRule());
+        addRule(new AvoidShortAuthenticationTagsRule());
+        addRule(new EnsureSignatureVerificationRule());
         // Add more default rules here as needed
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/CryptoRule.java
@@ -29,7 +29,19 @@ public enum CryptoRule {
     AVOID_FAST_HASH_ALGORITHMS(createRule(2,
             "Avoid using fast hashing algorithms", VULNERABILITY)),
     AVOID_REUSING_COUNTER_MODE_VECTORS(createRule(3,
-            "Avoid reusing counter mode initialization vectors", VULNERABILITY));
+            "Avoid reusing counter mode initialization vectors", VULNERABILITY)),
+    AVOID_WEAK_HASH_ALGORITHMS(createRule(4,
+            "Avoid using weak hashing and signature algorithms", VULNERABILITY)),
+    AVOID_HARDCODED_KEY_MATERIAL(createRule(5,
+            "Avoid hard-coded key material", VULNERABILITY)),
+    AVOID_WEAK_PGP_ALGORITHMS(createRule(6,
+            "Avoid using weak symmetric algorithms for PGP encryption", VULNERABILITY)),
+    ENSURE_PGP_INTEGRITY_CHECK(createRule(7,
+            "Avoid disabling integrity protection for PGP encryption", VULNERABILITY)),
+    AVOID_SHORT_AUTHENTICATION_TAGS(createRule(8,
+            "Avoid using short authentication tags for counter mode encryption", VULNERABILITY)),
+    ENSURE_SIGNATURE_VERIFICATION(createRule(9,
+            "Avoid discarding the result of a signature verification", VULNERABILITY));
 
     private final Rule rule;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/FunctionContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/FunctionContext.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
@@ -28,6 +29,8 @@ import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.projects.Document;
 import io.ballerina.scan.Reporter;
 import io.ballerina.tools.diagnostics.Location;
@@ -56,6 +59,7 @@ public class FunctionContext {
     private final Document document;
     private final String functionName;
     private final Location functionLocation;
+    private final boolean resultDiscarded;
     private  Map<String, ExpressionNode> paramExpressions = Map.of();
     private Map<String, ExpressionNode> varExpressions = Map.of();
 
@@ -84,7 +88,7 @@ public class FunctionContext {
         Optional<List<ParameterSymbol>> params = functionSymbol.typeDescriptor().params();
         // Create a default FunctionContext in case of missing parameters or arguments
         FunctionContext defaultFunctionContext = new FunctionContext(semanticModel, reporter, document, functionName,
-                location);
+                location, isResultDiscarded(functionCall));
         if (params.isEmpty() || arguments.isEmpty()) {
             return defaultFunctionContext;
         }
@@ -115,13 +119,14 @@ public class FunctionContext {
 
         // Add variable declarations up to the function call statement
         collectVariableExpressionsUntilStatement(functionBodyOpt.get(), statementNode.get(), varExpressions);
-        return new FunctionContext(semanticModel, reporter, document, functionName, location, paramExpressions,
-                varExpressions);
+        return new FunctionContext(semanticModel, reporter, document, functionName, location,
+                isResultDiscarded(functionCall), paramExpressions, varExpressions);
     }
 
     // Private constructor to enforce the use of the instance method
     private FunctionContext(SemanticModel semanticModel, Reporter reporter, Document document, String functionName,
-                            Location functionLocation) {
+                            Location functionLocation, boolean resultDiscarded) {
+        this.resultDiscarded = resultDiscarded;
         this.semanticModel = semanticModel;
         this.reporter = reporter;
         this.document = document;
@@ -131,9 +136,10 @@ public class FunctionContext {
 
     // Private constructor to enforce the use of the instance method
     private FunctionContext(SemanticModel semanticModel, Reporter reporter, Document document, String functionName,
-                            Location functionLocation, Map<String, ExpressionNode> paramExpressions,
+                            Location functionLocation, boolean resultDiscarded,
+                            Map<String, ExpressionNode> paramExpressions,
                             Map<String, ExpressionNode> varExpressions) {
-        this(semanticModel, reporter, document, functionName, functionLocation);
+        this(semanticModel, reporter, document, functionName, functionLocation, resultDiscarded);
         this.paramExpressions = paramExpressions;
         this.varExpressions = varExpressions;
     }
@@ -181,6 +187,55 @@ public class FunctionContext {
      */
     public Location functionLocation() {
         return functionLocation;
+    }
+
+    /**
+     * Returns whether the result of this call is bound to the wildcard {@code _} and therefore discarded.
+     *
+     * @return true if the result is discarded
+     */
+    public boolean isResultDiscarded() {
+        return resultDiscarded;
+    }
+
+    /**
+     * Walk up from the call to the statement containing it, and report whether the result is bound to the wildcard
+     * {@code _}. Anything else - a named variable, a condition, an argument - counts as a use.
+     *
+     * @param functionCall the function call expression node
+     * @return true if the result is discarded
+     */
+    private static boolean isResultDiscarded(FunctionCallExpressionNode functionCall) {
+        Node current = functionCall;
+        while (current != null) {
+            if (current instanceof VariableDeclarationNode variableDeclaration) {
+                return variableDeclaration.typedBindingPattern().bindingPattern().kind()
+                        .equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
+            }
+            if (current instanceof AssignmentStatementNode assignment) {
+                return assignment.varRef().kind().equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
+            }
+            if (current.kind().equals(SyntaxKind.FUNCTION_BODY_BLOCK)) {
+                return false;
+            }
+            current = current.parent();
+        }
+        return false;
+    }
+
+    /**
+     * Returns the argument expression written at the call site for the given parameter, without resolving a
+     * variable reference to whatever it was assigned.
+     * <p>
+     * Use this when the rule cares about what the author wrote at this position rather than about the value that
+     * reaches it. Resolving through a variable would both report code that is not literal at the call site and, for
+     * a variable that is reassigned later, report a value that is never actually used.
+     *
+     * @param paramName the parameter name
+     * @return the argument expression as written, if the parameter was supplied
+     */
+    public Optional<ExpressionNode> getRawParamExpression(String paramName) {
+        return Optional.ofNullable(paramExpressions.get(unescapeIdentifier(paramName)));
     }
 
     /**

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/FunctionContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/FunctionContext.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionStatementNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -39,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoAnalyzerUtils.collectVariableExpressionsUntilStatement;
 import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoAnalyzerUtils.getModuleLevelVarExpressions;
@@ -54,6 +56,8 @@ import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoAnaly
  * @since 2.9.1
  */
 public class FunctionContext {
+    private static final Set<SyntaxKind> RESULT_PASS_THROUGH_KINDS = Set.of(SyntaxKind.CHECK_EXPRESSION,
+            SyntaxKind.BRACED_EXPRESSION, SyntaxKind.TYPE_CAST_EXPRESSION, SyntaxKind.TRAP_EXPRESSION);
     private final SemanticModel semanticModel;
     private final Reporter reporter;
     private final Document document;
@@ -199,28 +203,28 @@ public class FunctionContext {
     }
 
     /**
-     * Walk up from the call to the statement containing it, and report whether the result is bound to the wildcard
-     * {@code _}. Anything else - a named variable, a condition, an argument - counts as a use.
+     * Report whether the result of the call is thrown away: bound to the wildcard {@code _}, or written as a
+     * statement of its own. Only the binding directly enclosing the call is considered, since a call nested inside
+     * another expression - an argument, a condition, an operand - has its result used by that expression even when
+     * the enclosing statement discards its own result.
      *
      * @param functionCall the function call expression node
      * @return true if the result is discarded
      */
     private static boolean isResultDiscarded(FunctionCallExpressionNode functionCall) {
-        Node current = functionCall;
-        while (current != null) {
-            if (current instanceof VariableDeclarationNode variableDeclaration) {
-                return variableDeclaration.typedBindingPattern().bindingPattern().kind()
-                        .equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
-            }
-            if (current instanceof AssignmentStatementNode assignment) {
-                return assignment.varRef().kind().equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
-            }
-            if (current.kind().equals(SyntaxKind.FUNCTION_BODY_BLOCK)) {
-                return false;
-            }
-            current = current.parent();
+        Node parent = functionCall.parent();
+        // Skip over the expressions that hand the result of the call through to the enclosing binding unchanged.
+        while (parent != null && RESULT_PASS_THROUGH_KINDS.contains(parent.kind())) {
+            parent = parent.parent();
         }
-        return false;
+        if (parent instanceof VariableDeclarationNode variableDeclaration) {
+            return variableDeclaration.typedBindingPattern().bindingPattern().kind()
+                    .equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
+        }
+        if (parent instanceof AssignmentStatementNode assignment) {
+            return assignment.varRef().kind().equals(SyntaxKind.WILDCARD_BINDING_PATTERN);
+        }
+        return parent instanceof ExpressionStatementNode;
     }
 
     /**

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidHardcodedKeyMaterialRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidHardcodedKeyMaterialRule.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoAnalyzerUtils;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_HARDCODED_KEY_MATERIAL;
+
+/**
+ * Rule to avoid hard-coded key material.
+ * <p>
+ * A key embedded in source is shared with everyone who can read the repository, cannot be rotated without a code
+ * change, and survives in version history after it is removed. Key material belongs in a {@code configurable}
+ * variable supplied at deployment.
+ * <p>
+ * This rule covers byte-array key material only. String literals in credential-shaped fields are covered by the
+ * language-level hard-coded secret rule; reporting them here as well would produce two findings for one problem.
+ *
+ * @since 2.12.2
+ */
+public class AvoidHardcodedKeyMaterialRule implements CryptoFunctionRule {
+
+    private static final String KEY_PARAM = "key";
+    private static final String PASSPHRASE_PARAM = "passphrase";
+
+    // Function name -> the parameter carrying key material
+    private static final Map<String, String> KEY_MATERIAL_PARAMS = Map.ofEntries(
+            Map.entry("hmacMd5", KEY_PARAM),
+            Map.entry("hmacSha1", KEY_PARAM),
+            Map.entry("hmacSha256", KEY_PARAM),
+            Map.entry("hmacSha384", KEY_PARAM),
+            Map.entry("hmacSha512", KEY_PARAM),
+            Map.entry("encryptAesCbc", KEY_PARAM),
+            Map.entry("encryptAesEcb", KEY_PARAM),
+            Map.entry("encryptAesGcm", KEY_PARAM),
+            Map.entry("decryptAesCbc", KEY_PARAM),
+            Map.entry("decryptAesEcb", KEY_PARAM),
+            Map.entry("decryptAesGcm", KEY_PARAM),
+            Map.entry("decryptPgp", PASSPHRASE_PARAM),
+            Map.entry("decryptStreamFromPgp", PASSPHRASE_PARAM));
+
+    private static final Set<String> APPLICABLE_FUNCTIONS = KEY_MATERIAL_PARAMS.keySet();
+
+    @Override
+    public void analyze(FunctionContext context) {
+        Optional<ExpressionNode> keyExpression =
+                context.getRawParamExpression(KEY_MATERIAL_PARAMS.get(context.functionName()));
+        if (keyExpression.isPresent() && CryptoAnalyzerUtils.isByteArrayLiteral(keyExpression.get())) {
+            context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+        }
+    }
+
+    @Override
+    public int getRuleId() {
+        return AVOID_HARDCODED_KEY_MATERIAL.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return APPLICABLE_FUNCTIONS.contains(context.functionName());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidShortAuthenticationTagsRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidShortAuthenticationTagsRule.java
@@ -73,11 +73,8 @@ public class AvoidShortAuthenticationTagsRule implements CryptoFunctionRule {
 
     private boolean isBelowMinimum(ExpressionNode valueExpr, SemanticModel semanticModel) {
         if (valueExpr.kind().equals(SyntaxKind.NUMERIC_LITERAL)) {
-            try {
-                return Integer.parseInt(((BasicLiteralNode) valueExpr).literalToken().text()) < MINIMUM_TAG_SIZE;
-            } catch (NumberFormatException e) {
-                return false;
-            }
+            return parseIntegerLiteral(((BasicLiteralNode) valueExpr).literalToken().text())
+                    .filter(tagSize -> tagSize < MINIMUM_TAG_SIZE).isPresent();
         }
         if (valueExpr instanceof NameReferenceNode refNode) {
             Optional<Symbol> refSymbol = semanticModel.symbol(refNode);
@@ -88,5 +85,24 @@ public class AvoidShortAuthenticationTagsRule implements CryptoFunctionRule {
             }
         }
         return false;
+    }
+
+    /**
+     * Parses an integer literal written either in decimal or, with a {@code 0x} prefix, in hexadecimal. A literal
+     * that is not an integer - a float, or a value too large for a long - yields an empty result, which leaves the
+     * call unreported rather than guessing at its size.
+     *
+     * @param literal the literal token text
+     * @return the value of the literal, if it is an integer
+     */
+    private static Optional<Long> parseIntegerLiteral(String literal) {
+        try {
+            if (literal.startsWith("0x") || literal.startsWith("0X")) {
+                return Optional.of(Long.parseLong(literal.substring(2), 16));
+            }
+            return Optional.of(Long.parseLong(literal));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidShortAuthenticationTagsRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidShortAuthenticationTagsRule.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.values.ConstantValue;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.NameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_SHORT_AUTHENTICATION_TAGS;
+
+/**
+ * Rule to avoid short GCM authentication tags.
+ * <p>
+ * The authentication tag is what makes GCM an authenticated mode. Shortening it reduces the work an attacker needs
+ * to forge a valid ciphertext: a 32-bit tag can be forged in roughly four billion attempts, which is tractable
+ * against a service that accepts repeated attempts.
+ * <p>
+ * The API documentation states the minimum is 96 bits, but the runtime validator also accepts 32 and 63, so a value
+ * below the documented minimum passes silently.
+ *
+ * @since 2.12.2
+ */
+public class AvoidShortAuthenticationTagsRule implements CryptoFunctionRule {
+
+    private static final String TAG_SIZE_PARAM = "tagSize";
+    private static final int MINIMUM_TAG_SIZE = 96;
+    private static final Set<String> GCM_FUNCTIONS = Set.of("encryptAesGcm", "decryptAesGcm");
+
+    @Override
+    public void analyze(FunctionContext context) {
+        Optional<ExpressionNode> tagSize = context.getParamExpression(TAG_SIZE_PARAM);
+        // If the parameter is absent the default of 128 applies, which is secure.
+        if (tagSize.isPresent() && isBelowMinimum(tagSize.get(), context.semanticModel())) {
+            context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+        }
+    }
+
+    @Override
+    public int getRuleId() {
+        return AVOID_SHORT_AUTHENTICATION_TAGS.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return GCM_FUNCTIONS.contains(context.functionName());
+    }
+
+    private boolean isBelowMinimum(ExpressionNode valueExpr, SemanticModel semanticModel) {
+        if (valueExpr.kind().equals(SyntaxKind.NUMERIC_LITERAL)) {
+            try {
+                return Integer.parseInt(((BasicLiteralNode) valueExpr).literalToken().text()) < MINIMUM_TAG_SIZE;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        if (valueExpr instanceof NameReferenceNode refNode) {
+            Optional<Symbol> refSymbol = semanticModel.symbol(refNode);
+            if (refSymbol.isPresent() && refSymbol.get() instanceof ConstantSymbol constantRef &&
+                    constantRef.constValue() instanceof ConstantValue constantValue &&
+                    constantValue.value() instanceof Long longValue) {
+                return longValue < MINIMUM_TAG_SIZE;
+            }
+        }
+        return false;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidWeakHashAlgorithmsRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidWeakHashAlgorithmsRule.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_HASH_ALGORITHMS;
+
+/**
+ * Rule to avoid MD5 and SHA-1 for hashing, message authentication and digital signatures.
+ * <p>
+ * Both algorithms are broken for security purposes: practical collisions exist for MD5 and SHA-1, so neither
+ * provides the collision resistance that integrity checking and signature verification depend on. SHA-256 or
+ * stronger should be used instead.
+ * <p>
+ * This rule is distinct from {@code crypto:2}, which covers the parameters of the password hashing functions.
+ * Here the algorithm itself is unsuitable regardless of how it is configured.
+ *
+ * @since 2.12.2
+ */
+public class AvoidWeakHashAlgorithmsRule implements CryptoFunctionRule {
+
+    private static final Set<String> WEAK_ALGORITHM_FUNCTIONS = Set.of(
+            // Hashing
+            "hashMd5",
+            "hashSha1",
+            // Message authentication
+            "hmacMd5",
+            "hmacSha1",
+            // Digital signatures
+            "signRsaMd5",
+            "signRsaSha1",
+            // Signature verification
+            "verifyRsaMd5Signature",
+            "verifyRsaSha1Signature"
+    );
+
+    @Override
+    public void analyze(FunctionContext context) {
+        context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+    }
+
+    @Override
+    public int getRuleId() {
+        return AVOID_WEAK_HASH_ALGORITHMS.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return WEAK_ALGORITHM_FUNCTIONS.contains(context.functionName());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidWeakPgpAlgorithmsRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/AvoidWeakPgpAlgorithmsRule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoAnalyzerUtils;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.AVOID_WEAK_PGP_ALGORITHMS;
+
+/**
+ * Rule to avoid weak symmetric algorithms in PGP encryption.
+ * <p>
+ * {@code SymmetricKeyAlgorithmTags} allows several algorithms that are no longer fit for use. {@code NULL} applies
+ * no encryption at all; DES, IDEA, CAST5, SAFER and BLOWFISH have inadequate key or block sizes; and Triple DES is
+ * vulnerable to birthday attacks on its 64-bit block. AES-128 or stronger should be used instead.
+ * <p>
+ * The enum members carry numeric string values, so the check compares the resolved constant value rather than the
+ * member name. Values "0" through "6" are the weak members.
+ *
+ * @since 2.12.2
+ */
+public class AvoidWeakPgpAlgorithmsRule implements CryptoFunctionRule {
+
+    private static final String SYMMETRIC_KEY_ALGORITHM_PARAM = "symmetricKeyAlgorithm";
+    private static final Set<String> PGP_ENCRYPT_FUNCTIONS = Set.of("encryptPgp", "encryptStreamAsPgp");
+
+    // NULL, IDEA, TRIPLE_DES, CAST5, BLOWFISH, SAFER, DES
+    private static final Set<String> WEAK_ALGORITHM_VALUES = Set.of("0", "1", "2", "3", "4", "5", "6");
+
+    @Override
+    public void analyze(FunctionContext context) {
+        Optional<String> algorithm = CryptoAnalyzerUtils.getStringValue(SYMMETRIC_KEY_ALGORITHM_PARAM, context);
+        if (algorithm.isPresent() && WEAK_ALGORITHM_VALUES.contains(algorithm.get())) {
+            context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+        }
+    }
+
+    @Override
+    public int getRuleId() {
+        return AVOID_WEAK_PGP_ALGORITHMS.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return PGP_ENCRYPT_FUNCTIONS.contains(context.functionName());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/EnsurePgpIntegrityCheckRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/EnsurePgpIntegrityCheckRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.ENSURE_PGP_INTEGRITY_CHECK;
+
+/**
+ * Rule to keep PGP integrity protection enabled.
+ * <p>
+ * Setting {@code withIntegrityCheck} to false omits the modification detection code from the message. Without it a
+ * recipient cannot tell whether the ciphertext was altered in transit, so tampering succeeds silently.
+ *
+ * @since 2.12.2
+ */
+public class EnsurePgpIntegrityCheckRule implements CryptoFunctionRule {
+
+    private static final String WITH_INTEGRITY_CHECK_PARAM = "withIntegrityCheck";
+    private static final Set<String> PGP_ENCRYPT_FUNCTIONS = Set.of("encryptPgp", "encryptStreamAsPgp");
+
+    @Override
+    public void analyze(FunctionContext context) {
+        Optional<ExpressionNode> integrityCheck = context.getParamExpression(WITH_INTEGRITY_CHECK_PARAM);
+        // Only an explicit `false` is actionable. The default is true, and a non-literal value cannot be resolved.
+        if (integrityCheck.isPresent()
+                && "false".equals(integrityCheck.get().toSourceCode().trim())) {
+            context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+        }
+    }
+
+    @Override
+    public int getRuleId() {
+        return ENSURE_PGP_INTEGRITY_CHECK.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return PGP_ENCRYPT_FUNCTIONS.contains(context.functionName());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/EnsureSignatureVerificationRule.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/crypto/compiler/staticcodeanalyzer/functionrules/EnsureSignatureVerificationRule.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.functionrules;
+
+import io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.FunctionContext;
+
+import java.util.Set;
+
+import static io.ballerina.stdlib.crypto.compiler.staticcodeanalyzer.CryptoRule.ENSURE_SIGNATURE_VERIFICATION;
+
+/**
+ * Rule to ensure the result of a signature verification is used.
+ * <p>
+ * The verify functions return whether the signature is valid; they do not fail when it is invalid. Discarding that
+ * boolean means the signature is computed and then ignored, so a forged or tampered message is accepted. The code
+ * reads as though verification is happening, which is what makes this worth reporting.
+ *
+ * @since 2.12.2
+ */
+public class EnsureSignatureVerificationRule implements CryptoFunctionRule {
+
+    private static final Set<String> VERIFY_FUNCTIONS = Set.of(
+            "verifyRsaMd5Signature",
+            "verifyRsaSha1Signature",
+            "verifyRsaSha256Signature",
+            "verifyRsaSha384Signature",
+            "verifyRsaSha512Signature",
+            "verifyRsaSsaPss256Signature",
+            "verifySha256withEcdsaSignature",
+            "verifySha384withEcdsaSignature",
+            "verifyMlDsa65Signature");
+
+    @Override
+    public void analyze(FunctionContext context) {
+        if (context.isResultDiscarded()) {
+            context.reporter().reportIssue(context.document(), context.functionLocation(), getRuleId());
+        }
+    }
+
+    @Override
+    public int getRuleId() {
+        return ENSURE_SIGNATURE_VERIFICATION.getId();
+    }
+
+    @Override
+    public boolean isApplicable(FunctionContext context) {
+        return VERIFY_FUNCTIONS.contains(context.functionName());
+    }
+}

--- a/compiler-plugin/src/main/resources/rules.json
+++ b/compiler-plugin/src/main/resources/rules.json
@@ -13,5 +13,35 @@
     "id": 3,
     "kind": "VULNERABILITY",
     "description": "Avoid reusing counter mode initialization vectors"
+  },
+  {
+    "id": 4,
+    "kind": "VULNERABILITY",
+    "description": "Avoid using weak hashing and signature algorithms"
+  },
+  {
+    "id": 5,
+    "kind": "VULNERABILITY",
+    "description": "Avoid hard-coded key material"
+  },
+  {
+    "id": 6,
+    "kind": "VULNERABILITY",
+    "description": "Avoid using weak symmetric algorithms for PGP encryption"
+  },
+  {
+    "id": 7,
+    "kind": "VULNERABILITY",
+    "description": "Avoid disabling integrity protection for PGP encryption"
+  },
+  {
+    "id": 8,
+    "kind": "VULNERABILITY",
+    "description": "Avoid using short authentication tags for counter mode encryption"
+  },
+  {
+    "id": 9,
+    "kind": "VULNERABILITY",
+    "description": "Avoid discarding the result of a signature verification"
   }
 ]

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1325,6 +1325,13 @@ The following static code rules are applied to the Crypto module.
 
 Using weak or outdated encryption modes and padding schemes can compromise the security of encrypted data, even when strong algorithms are used.
 
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:1 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-327](https://cwe.mitre.org/data/definitions/327.html), [CWE-780](https://cwe.mitre.org/data/definitions/780.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
+
 #### 12.1.1. Why this is an issue?
 
 Encryption algorithms are essential for protecting sensitive information and ensuring secure communications. When implementing encryption, it's critical to select not only strong algorithms but also secure modes of operation and padding schemes. Using weak or outdated encryption modes can compromise the security of otherwise strong algorithms.
@@ -1411,6 +1418,13 @@ OAEP such as OAEPwithMD5andMGF1, OAEPWithSHA1AndMGF1, OAEPWithSHA256AndMGF1, OAE
 ### 12.2. Avoid using fast hashing algorithms
 
 Storing passwords in plaintext or using fast hashing algorithms creates significant security vulnerabilities. If an attacker gains access to your database, plaintext passwords are immediately compromised. Similarly, passwords hashed with fast algorithms (like MD5, SHA-1, or SHA-256 without sufficient iterations) can be rapidly cracked using modern hardware.
+
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:2 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-916](https://cwe.mitre.org/data/definitions/916.html), [CWE-327](https://cwe.mitre.org/data/definitions/327.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
 
 #### 12.2.1. Why this is an issue?
 
@@ -1545,6 +1559,13 @@ public function hashPassword() returns error? {
 
 When using encryption algorithms in counter mode (such as AES-GCM, AES-CCM, or AES-CTR), initialization vectors (IVs) or nonces should never be reused with the same encryption key. Reusing IVs with the same key can completely compromise the security of the encryption.
 
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:3 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-323](https://cwe.mitre.org/data/definitions/323.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
+
 #### 12.3.1. Why this is an issue?
 
 Counter mode encryption relies on unique initialization vectors to ensure security. When the same IV is used with the same encryption key for different plaintexts, it creates serious vulnerabilities that can lead to:
@@ -1660,6 +1681,13 @@ public function encryptMessage(string message) returns [byte[], byte[12]]|error 
 
 MD5 and SHA-1 are broken for any purpose that depends on collision resistance.
 
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:4 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-327](https://cwe.mitre.org/data/definitions/327.html), [CWE-328](https://cwe.mitre.org/data/definitions/328.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
+
 #### 12.4.1. Why this is an issue?
 
 Practical collision attacks exist against both MD5 and SHA-1: an attacker can construct two different inputs with the same digest at modest cost. A signature is computed over a digest, so a signature scheme built on either algorithm inherits that weakness directly.
@@ -1695,6 +1723,13 @@ byte[] signature = check crypto:signRsaSha256("payload".toBytes(), privateKey);
 ### 12.5. Avoid hard-coded key material
 
 A key written into the source is shared with everyone who can read the source.
+
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:5 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-321](https://cwe.mitre.org/data/definitions/321.html), [CWE-798](https://cwe.mitre.org/data/definitions/798.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
 
 #### 12.5.1. Why this is an issue?
 
@@ -1736,6 +1771,13 @@ byte[] mac = check crypto:hmacSha256("payload".toBytes(), key);
 
 The PGP symmetric algorithm decides the strength of the encryption, and `NULL` disables it.
 
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:6 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-327](https://cwe.mitre.org/data/definitions/327.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
+
 #### 12.6.1. Why this is an issue?
 
 `Options.symmetricKeyAlgorithm` selects the cipher used for the message body. `DES`, `TRIPLE_DES`, `IDEA`, `BLOWFISH`, `CAST5` and `SAFER` are obsolete: their block or key sizes are too small to resist current attacks. `NULL` performs no encryption at all, so the message is carried in the clear inside a container that appears encrypted.
@@ -1772,6 +1814,13 @@ byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc"
 ### 12.7. Avoid disabling integrity protection for PGP encryption
 
 Without the modification detection code, tampering with the ciphertext is undetectable.
+
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:7 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-353](https://cwe.mitre.org/data/definitions/353.html), [CWE-354](https://cwe.mitre.org/data/definitions/354.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
 
 #### 12.7.1. Why this is an issue?
 
@@ -1811,6 +1860,13 @@ byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc"
 
 A short GCM tag can be forged, which removes the authentication the mode provides.
 
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:8 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-327](https://cwe.mitre.org/data/definitions/327.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
+
 #### 12.8.1. Why this is an issue?
 
 The authentication tag is what makes GCM an authenticated mode: it is the value the recipient checks to know the ciphertext was not altered. Its length sets the work required to forge one, and the strength falls exponentially as it shortens. The documented minimum is 96 bits.
@@ -1845,6 +1901,13 @@ byte[] encrypted = check crypto:encryptAesGcm("payload".toBytes(), key, iv, cryp
 ### 12.9. Avoid discarding the result of a signature verification
 
 A verification whose result is thrown away has not verified anything.
+
+| Property              | Description |
+|-----------------------|-------------|
+| **Rule ID**           | ballerina/crypto:9 |
+| **Rule Kind**         | Vulnerability |
+| **CWE**               | [CWE-347](https://cwe.mitre.org/data/definitions/347.html) |
+| **OWASP Top 10:2025** | [A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/) |
 
 #### 12.9.1. Why this is an issue?
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Authors_: @shafreenAnfar @bhashinee @Nuvindu
 _Reviewers_: @shafreenAnfar
 _Created_: 2022/08/23
-_Updated_: 2026/05/13
+_Updated_: 2026/09/03
 _Edition_: Swan Lake
 
 ## Introduction
@@ -115,6 +115,12 @@ The conforming implementation of the specification is released and included in t
     - 12.1 [Avoid using insecure cipher modes or padding schemes](#121-avoid-using-insecure-cipher-modes-or-padding-schemes)
     - 12.2 [Avoid using fast hashing algorithms](#122-avoid-using-fast-hashing-algorithms)
     - 12.3 [Avoid reusing counter mode initialization vectors](#123-avoid-reusing-counter-mode-initialization-vectors)
+    - 12.4 [Avoid using weak hashing and signature algorithms](#124-avoid-using-weak-hashing-and-signature-algorithms)
+    - 12.5 [Avoid hard-coded key material](#125-avoid-hard-coded-key-material)
+    - 12.6 [Avoid using weak symmetric algorithms for PGP encryption](#126-avoid-using-weak-symmetric-algorithms-for-pgp-encryption)
+    - 12.7 [Avoid disabling integrity protection for PGP encryption](#127-avoid-disabling-integrity-protection-for-pgp-encryption)
+    - 12.8 [Avoid using short authentication tags for counter mode encryption](#128-avoid-using-short-authentication-tags-for-counter-mode-encryption)
+    - 12.9 [Avoid discarding the result of a signature verification](#129-avoid-discarding-the-result-of-a-signature-verification)
 
 ## 1. Overview
 
@@ -1305,15 +1311,21 @@ The following static code rules are applied to the Crypto module.
 
 | Id                 | Kind          | Description                                                                                                       |
 |--------------------|---------------|-------------------------------------------------------------------------------------------------------------------|
-| ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#111-avoid-using-insecure-cipher-modes-or-padding-schemes) |
-| ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#112-avoid-using-fast-hashing-algorithms)                                   |
-| ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#113-avoid-reusing-counter-mode-initialization-vectors)       |
+| ballerina/crypto:1 | VULNERABILITY | [Avoid using insecure cipher modes or padding schemes](#121-avoid-using-insecure-cipher-modes-or-padding-schemes) |
+| ballerina/crypto:2 | VULNERABILITY | [Avoid using fast hashing algorithms](#122-avoid-using-fast-hashing-algorithms)                                   |
+| ballerina/crypto:3 | VULNERABILITY | [Avoid reusing counter mode initialization vectors](#123-avoid-reusing-counter-mode-initialization-vectors)       |
+| ballerina/crypto:4 | VULNERABILITY | [Avoid using weak hashing and signature algorithms](#124-avoid-using-weak-hashing-and-signature-algorithms) |
+| ballerina/crypto:5 | VULNERABILITY | [Avoid hard-coded key material](#125-avoid-hard-coded-key-material) |
+| ballerina/crypto:6 | VULNERABILITY | [Avoid using weak symmetric algorithms for PGP encryption](#126-avoid-using-weak-symmetric-algorithms-for-pgp-encryption) |
+| ballerina/crypto:7 | VULNERABILITY | [Avoid disabling integrity protection for PGP encryption](#127-avoid-disabling-integrity-protection-for-pgp-encryption) |
+| ballerina/crypto:8 | VULNERABILITY | [Avoid using short authentication tags for counter mode encryption](#128-avoid-using-short-authentication-tags-for-counter-mode-encryption) |
+| ballerina/crypto:9 | VULNERABILITY | [Avoid discarding the result of a signature verification](#129-avoid-discarding-the-result-of-a-signature-verification) |
 
-### 12.1 Avoid using insecure cipher modes or padding schemes
+### 12.1. Avoid using insecure cipher modes or padding schemes
 
 Using weak or outdated encryption modes and padding schemes can compromise the security of encrypted data, even when strong algorithms are used.
 
-## 12.1.1. Why this is an issue?
+#### 12.1.1. Why this is an issue?
 
 Encryption algorithms are essential for protecting sensitive information and ensuring secure communications. When implementing encryption, it's critical to select not only strong algorithms but also secure modes of operation and padding schemes. Using weak or outdated encryption modes can compromise the security of otherwise strong algorithms.
 
@@ -1325,7 +1337,7 @@ The security risks of using weak encryption modes include:
 - Replay attacks where valid encrypted data is reused maliciously
 - Known-plaintext attacks that can reveal encryption keys
 
-## 12.1.2. What is the potential impact?
+#### 12.1.2. What is the potential impact?
 
 Common vulnerable patterns include:
 
@@ -1335,11 +1347,11 @@ Common vulnerable patterns include:
 - Relying on outdated padding methods like PKCS1v1.5
 - Using stream ciphers with insufficient initialization vectors
 
-## 12.1.3. How can I fix this?
+#### 12.1.3. How can I fix this?
 
 Choose secure encryption modes and padding schemes that provide both confidentiality and integrity protection.
 
-### 12.1.3.1 AES Encryption Example
+##### 12.1.3.1 AES Encryption Example
 
 **Non-compliant code :**
 
@@ -1363,7 +1375,7 @@ byte[] cipherText = check crypto:encryptAesGcm(data, key, initialVector);
 
 AES-GCM (Galois/Counter Mode) provides authenticated encryption, ensuring both confidentiality and integrity of the encrypted data.
 
-### 12.1.3.2 RSA Encryption Example
+##### 12.1.3.2 RSA Encryption Example
 
 **Non-compliant code :**
 
@@ -1384,7 +1396,7 @@ byte[] cipherText = check crypto:encryptRsaEcb(data, publicKey, crypto:OAEPwithM
 
 OAEP such as OAEPwithMD5andMGF1, OAEPWithSHA1AndMGF1, OAEPWithSHA256AndMGF1, OAEPwithSHA384andMGF1, and OAEPwithSHA512andMGF1 should be used for RSA encryption to enhance security.
 
-## Additional Resources
+#### 12.1.4. Additional Resources
 
 - OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
 - OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
@@ -1396,11 +1408,11 @@ OAEP such as OAEPwithMD5andMGF1, OAEPWithSHA1AndMGF1, OAEPWithSHA256AndMGF1, OAE
 - CWE - [CWE-780 - Use of RSA Algorithm without OAEP](https://cwe.mitre.org/data/definitions/780)
 - [CERT, MSC61-J.](https://wiki.sei.cmu.edu/confluence/x/hDdGBQ) - Do not use insecure or weak cryptographic algorithms
 
-### 12.2 Avoid using fast hashing algorithms
+### 12.2. Avoid using fast hashing algorithms
 
 Storing passwords in plaintext or using fast hashing algorithms creates significant security vulnerabilities. If an attacker gains access to your database, plaintext passwords are immediately compromised. Similarly, passwords hashed with fast algorithms (like MD5, SHA-1, or SHA-256 without sufficient iterations) can be rapidly cracked using modern hardware.
 
-## 12.2.1. Why this is an issue?
+#### 12.2.1. Why this is an issue?
 
 When using PBKDF2 (Password-Based Key Derivation Function 2), the iteration count is critical for security. Higher iteration counts increase the computational effort required to hash passwords, making brute-force attacks more difficult and time-consuming.
 
@@ -1427,7 +1439,7 @@ For PBKDF2:
 
 If performance constraints make these recommendations impractical, the iteration count should never be lower than 100,000.
 
-## 12.2.2. What is the potential impact?
+#### 12.2.2. What is the potential impact?
 
 The security risks of using fast hashing algorithms include:
 
@@ -1437,11 +1449,11 @@ The security risks of using fast hashing algorithms include:
 - GPU-accelerated cracking tools can process billions of hashes per second
 - Credential stuffing attacks using compromised password lists
 
-## 12.2.3. How can I fix this?
+#### 12.2.3. How can I fix this?
 
 Use secure password hashing algorithms with appropriate parameters that provide sufficient computational cost to resist brute-force attacks.
 
-### 12.2.3.1 BCrypt Hashing Example
+##### 12.2.3.1 BCrypt Hashing Example
 
 **Non-compliant code:**
 
@@ -1467,7 +1479,7 @@ public function hashPassword() returns error? {
 }
 ```
 
-### 12.2.3.2 Argon2 Hashing Example
+##### 12.2.3.2 Argon2 Hashing Example
 
 **Non-compliant code:**
 
@@ -1493,7 +1505,7 @@ public function hashPassword() returns error? {
 }
 ```
 
-### 12.2.3.3 PBKDF2 Hashing Example
+##### 12.2.3.3 PBKDF2 Hashing Example
 
 **Non-compliant code:**
 
@@ -1519,7 +1531,7 @@ public function hashPassword() returns error? {
 }
 ```
 
-## 12.2.4 Additional Resources
+#### 12.2.4. Additional Resources
 
 - OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
 - OWASP - [Top 10 2021 Category A4 - Insecure Design](https://owasp.org/Top10/A04_2021-Insecure_Design/)
@@ -1529,11 +1541,11 @@ public function hashPassword() returns error? {
 - CWE - [CWE-916 - Use of Password Hash With Insufficient Computational Effort](https://cwe.mitre.org/data/definitions/916)
 - STIG Viewer - [Application Security and Development: V-222542](https://stigviewer.com/stigs/application_security_and_development/2024-12-06/finding/V-222542) - The application must only store cryptographic representations of passwords.
 
-### 12.3 Avoid reusing counter mode initialization vectors
+### 12.3. Avoid reusing counter mode initialization vectors
 
 When using encryption algorithms in counter mode (such as AES-GCM, AES-CCM, or AES-CTR), initialization vectors (IVs) or nonces should never be reused with the same encryption key. Reusing IVs with the same key can completely compromise the security of the encryption.
 
-## 12.3.1. Why this is an issue?
+#### 12.3.1. Why this is an issue?
 
 Counter mode encryption relies on unique initialization vectors to ensure security. When the same IV is used with the same encryption key for different plaintexts, it creates serious vulnerabilities that can lead to:
 
@@ -1551,7 +1563,7 @@ The security risks of reusing IVs in counter mode include:
 - Violation of the security guarantees provided by the encryption algorithm
 - Exposure of sensitive data even when using strong encryption algorithms
 
-## 12.3.2. What is the potential impact?
+#### 12.3.2. What is the potential impact?
 
 Reusing initialization vectors in counter mode encryption creates critical security vulnerabilities:
 
@@ -1560,11 +1572,11 @@ Reusing initialization vectors in counter mode encryption creates critical secur
 - **Key recovery**: In some scenarios, repeated IV usage can lead to recovery of the encryption key itself
 - **Complete system compromise**: Once the encryption is broken, all data encrypted with that key becomes vulnerable
 
-## 12.3.3. How can I fix this?
+#### 12.3.3. How can I fix this?
 
 Generate cryptographically secure random initialization vectors for each encryption operation and ensure they are never reused with the same key.
 
-### 12.3.3.1 AES-GCM Encryption Example
+##### 12.3.3.1 AES-GCM Encryption Example
 
 **Non-compliant code:**
 
@@ -1599,7 +1611,7 @@ public function encryptData(string data) returns [byte[], byte[16]]|error {
 
 This compliant approach generates a cryptographically secure random initialization vector for each encryption operation and returns it along with the encrypted data. The IV must be stored alongside the encrypted data (but doesn't need to be kept secret) to allow for decryption later.
 
-### 12.3.3.2 AES-CBC Encryption Example
+##### 12.3.3.2 AES-CBC Encryption Example
 
 **Non-compliant code:**
 
@@ -1632,7 +1644,7 @@ public function encryptMessage(string message) returns [byte[], byte[12]]|error 
 }
 ```
 
-## 12.3.4 Additional Resources
+#### 12.3.4. Additional Resources
 
 - OWASP - [Top 10 2021 Category A2 - Cryptographic Failures](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/)
 - OWASP - [Top 10 2017 Category A3 - Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
@@ -1643,3 +1655,227 @@ public function encryptMessage(string message) returns [byte[], byte[12]]|error 
 - [NIST, SP-800-38A](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf) - Recommendation for Block Cipher Modes of Operation
 - [NIST, SP-800-38C](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf) - Recommendation for Block Cipher Modes of Operation: The CCM Mode for Authentication and Confidentiality
 - [NIST, SP-800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf) - Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC
+
+### 12.4. Avoid using weak hashing and signature algorithms
+
+MD5 and SHA-1 are broken for any purpose that depends on collision resistance.
+
+#### 12.4.1. Why this is an issue?
+
+Practical collision attacks exist against both MD5 and SHA-1: an attacker can construct two different inputs with the same digest at modest cost. A signature is computed over a digest, so a signature scheme built on either algorithm inherits that weakness directly.
+
+#### 12.4.2. What is the potential impact?
+
+An attacker can produce a second document that carries a signature made for the first, so a signature no longer establishes what was signed. Where the digest is used to detect tampering, modified content passes the check.
+
+#### 12.4.3. How can I fix this?
+
+Use SHA-256 or stronger for hashing, and the matching signature functions.
+
+**Non-compliant code:**
+
+```ballerina
+byte[] digest = crypto:hashMd5("payload".toBytes());
+byte[] signature = check crypto:signRsaSha1("payload".toBytes(), privateKey);
+```
+
+**Compliant code:**
+
+```ballerina
+byte[] digest = crypto:hashSha256("payload".toBytes());
+byte[] signature = check crypto:signRsaSha256("payload".toBytes(), privateKey);
+```
+
+#### 12.4.4. Additional Resources
+
+- [CWE-327: Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327.html)
+- [CWE-328: Use of Weak Hash](https://cwe.mitre.org/data/definitions/328.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)
+
+### 12.5. Avoid hard-coded key material
+
+A key written into the source is shared with everyone who can read the source.
+
+#### 12.5.1. Why this is an issue?
+
+Key material embedded in a program is present in the repository, in every clone of it, in build artefacts and in any image built from them. It cannot be rotated without a code change and a redeployment, and it is identical across every environment the code runs in.
+
+The rule reports a byte array literal used as key material, which is the form a name-based check cannot see: a literal such as `[1, 2, 3, ...]` passed as an HMAC key looks nothing like a credential. String literals in fields such as `KeyStore.password` are left to the language-level hard-coded secret rule so the same finding is not reported twice.
+
+The rule reads the expression written at the call site rather than resolving a variable back to its initialiser. A key that is declared with a literal and then filled with random bytes is not hard-coded, and resolving would report it.
+
+#### 12.5.2. What is the potential impact?
+
+Anyone with read access to the source, including a leaked repository or a published image layer, holds the key, and every deployment shares it.
+
+#### 12.5.3. How can I fix this?
+
+Declare the key `configurable` and supply it at deployment, or read it from a key store.
+
+**Non-compliant code:**
+
+```ballerina
+byte[] key = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+byte[] mac = check crypto:hmacSha256("payload".toBytes(), key);
+```
+
+**Compliant code:**
+
+```ballerina
+configurable byte[] & readonly key = ?;
+byte[] mac = check crypto:hmacSha256("payload".toBytes(), key);
+```
+
+#### 12.5.4. Additional Resources
+
+- [CWE-321: Use of Hard-coded Cryptographic Key](https://cwe.mitre.org/data/definitions/321.html)
+- [CWE-798: Use of Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)
+
+### 12.6. Avoid using weak symmetric algorithms for PGP encryption
+
+The PGP symmetric algorithm decides the strength of the encryption, and `NULL` disables it.
+
+#### 12.6.1. Why this is an issue?
+
+`Options.symmetricKeyAlgorithm` selects the cipher used for the message body. `DES`, `TRIPLE_DES`, `IDEA`, `BLOWFISH`, `CAST5` and `SAFER` are obsolete: their block or key sizes are too small to resist current attacks. `NULL` performs no encryption at all, so the message is carried in the clear inside a container that appears encrypted.
+
+#### 12.6.2. What is the potential impact?
+
+The message contents are recoverable by an attacker who captures the ciphertext, and with `NULL` no work is required at all.
+
+#### 12.6.3. How can I fix this?
+
+Use AES-256, or leave the option unset and take the library default.
+
+**Non-compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc", {
+    symmetricKeyAlgorithm: crypto:TRIPLE_DES
+});
+```
+
+**Compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc", {
+    symmetricKeyAlgorithm: crypto:AES_256
+});
+```
+
+#### 12.6.4. Additional Resources
+
+- [CWE-327: Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)
+
+### 12.7. Avoid disabling integrity protection for PGP encryption
+
+Without the modification detection code, tampering with the ciphertext is undetectable.
+
+#### 12.7.1. Why this is an issue?
+
+PGP encryption carries a modification detection code that lets the recipient tell whether the ciphertext was altered in transit. Setting `withIntegrityCheck` to `false` removes it, so decryption succeeds whether or not the message is the one that was sent.
+
+#### 12.7.2. What is the potential impact?
+
+An attacker who can modify the ciphertext can alter the decrypted message without the recipient noticing, and the absence of an integrity check also enables chosen-ciphertext attacks against the encryption itself.
+
+#### 12.7.3. How can I fix this?
+
+Leave `withIntegrityCheck` at its default of `true`.
+
+**Non-compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc", {
+    withIntegrityCheck: false
+});
+```
+
+**Compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptPgp("payload".toBytes(), "public_key.asc", {
+    withIntegrityCheck: true
+});
+```
+
+#### 12.7.4. Additional Resources
+
+- [CWE-353: Missing Support for Integrity Check](https://cwe.mitre.org/data/definitions/353.html)
+- [CWE-354: Improper Validation of Integrity Check Value](https://cwe.mitre.org/data/definitions/354.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)
+
+### 12.8. Avoid using short authentication tags for counter mode encryption
+
+A short GCM tag can be forged, which removes the authentication the mode provides.
+
+#### 12.8.1. Why this is an issue?
+
+The authentication tag is what makes GCM an authenticated mode: it is the value the recipient checks to know the ciphertext was not altered. Its length sets the work required to forge one, and the strength falls exponentially as it shortens. The documented minimum is 96 bits.
+
+The native validator accepts values below that minimum without complaint, so a caller can weaken authentication to the point of forgeability and see nothing at run time. This rule reports any `tagSize` below 96, written in decimal or hexadecimal.
+
+#### 12.8.2. What is the potential impact?
+
+An attacker can construct ciphertext that passes the authentication check, so the recipient accepts data the sender never produced.
+
+#### 12.8.3. How can I fix this?
+
+Use a tag of at least 96 bits, and prefer the full 128.
+
+**Non-compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptAesGcm("payload".toBytes(), key, iv, crypto:NONE, 32);
+```
+
+**Compliant code:**
+
+```ballerina
+byte[] encrypted = check crypto:encryptAesGcm("payload".toBytes(), key, iv, crypto:NONE, 128);
+```
+
+#### 12.8.4. Additional Resources
+
+- [CWE-327: Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)
+
+### 12.9. Avoid discarding the result of a signature verification
+
+A verification whose result is thrown away has not verified anything.
+
+#### 12.9.1. Why this is an issue?
+
+The `verify*Signature` functions return a `boolean` saying whether the signature matched. They do not fail when it does not. Discarding that result means the call runs, succeeds, and establishes nothing, while the code around it reads as though the signature had been checked.
+
+The rule reports only a result that is provably discarded: bound to a wildcard, assigned to a wildcard, or used as an expression statement. A result passed onward through `check`, a braced expression, a type cast or `trap` is still consumed and is not reported.
+
+#### 12.9.2. What is the potential impact?
+
+Every signature is effectively accepted, so a forged or altered message passes the same path a genuine one does. The defect is invisible in review because the verification call is present.
+
+#### 12.9.3. How can I fix this?
+
+Bind the result and act on it.
+
+**Non-compliant code:**
+
+```ballerina
+boolean _ = check crypto:verifyRsaSha256Signature(payload, signature, publicKey);
+```
+
+**Compliant code:**
+
+```ballerina
+boolean verified = check crypto:verifyRsaSha256Signature(payload, signature, publicKey);
+if !verified {
+    return error("signature verification failed");
+}
+```
+
+#### 12.9.4. Additional Resources
+
+- [CWE-347: Improper Verification of Cryptographic Signature](https://cwe.mitre.org/data/definitions/347.html)
+- [OWASP Top 10:2025 A04 Cryptographic Failures](https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/)


### PR DESCRIPTION
## Purpose

Part of: https://github.com/ballerina-platform/ballerina-library/issues/9135

Expand the `ballerina/crypto` static analyzer from three rules to nine. The new rules cover key material, PGP configuration, authentication tag length and unchecked signature verification — areas of the module's security surface that had no coverage at all.

All six fit the existing `FUNCTION_CALL` hook in `CryptoCodeAnalyzer` and need no architectural change.

## Rules added

| ID | Rule | CWE |
|---|---|---|
| `crypto:4` | Avoid using weak hashing and signature algorithms | 327, 328 |
| `crypto:5` | Avoid hard-coded key material | 321, 798 |
| `crypto:6` | Avoid using weak symmetric algorithms for PGP encryption | 327 |
| `crypto:7` | Avoid disabling integrity protection for PGP encryption | 353, 354 |
| `crypto:8` | Avoid using short authentication tags for counter mode encryption | 327 |
| `crypto:9` | Avoid discarding the result of a signature verification | 347 |

## Design notes

**`crypto:5` reads the raw argument at the call site rather than resolving variables.** Resolving a simple name reference back to its initialiser is wrong when the variable is later overwritten — the existing `rule1` fixture declares a literal-initialised key and then fills it with random bytes, which a resolving rule reports as hard-coded. `FunctionContext.getRawParamExpression` is added for this, since `getParamExpression` resolves references by design. The rule reports byte-array literals only; string literals in `KeyStore.password` and similar are left to the language-level hard-coded secret rule to avoid double-reporting the same finding from two places.

**`crypto:9` reports only a provably discarded result** — a wildcard binding or an expression statement. `FunctionContext` computes this as a `boolean` during construction rather than exposing the call node, which keeps the context from handing out its internal representation and avoids a SpotBugs suppression.

**`crypto:8` flags `tagSize` below 96.** The documented minimum is 96, but the native validator accepts smaller values silently, so a caller can weaken authentication to the point of forgeability with no runtime complaint. This is worth raising with the crypto team independently of the rule.

## Scope

Rules requiring data-flow analysis are deliberately out of scope and are not approximated syntactically: non-constant-time MAC comparison, HKDF with an empty salt, and PBKDF2 PRF selection.

## Testing

Fixtures `rule4` through `rule9` each carry triggering and non-triggering cases in the same package, with expected output under `expected_output/`.

`:crypto-compiler-plugin:checkstyleMain`, `:crypto-compiler-plugin:spotbugsMain` and `:crypto-compiler-plugin-tests:test` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expanded the `ballerina/crypto` static analyzer with six additional code quality checks.
- Added raw argument inspection and result-usage tracking.
- Registered the new checks and rule metadata.
- Added positive and negative test fixtures with expected outputs.
- Updated the specification and package dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->